### PR TITLE
Remove Accept=true from socket unit file.

### DIFF
--- a/packages/systemd/desktop-security-center.socket
+++ b/packages/systemd/desktop-security-center.socket
@@ -3,7 +3,6 @@ Description=Socket for desktop-security-center backend/frontend communication
 
 [Socket]
 ListenStream=%t/desktop-security-center.socket
-Accept=true
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
Causes "failed to queue service startup job: Invalid argument. Failed with result 'resources'."

The service must be templated as per https://stackoverflow.com/a/64597081. I don't know why and I won't bother.