### PR TITLE
fix: do not error if Is*Service is called while unattached.

### DIFF
--- a/packages/backend/ubuntu-pro.go
+++ b/packages/backend/ubuntu-pro.go
@@ -90,13 +90,13 @@ func NewProServer(conn *dbus.Conn) (*ProServer, error) {
     return s, nil
 }
 
-func isServiceEnabled(obj dbus.BusObject, manager dbus.BusObject) (bool, error) {
+func (s *ProServer) isServiceEnabled(obj dbus.BusObject) (bool, error) {
     /* Although it is pointless to call isServiceEnabled if the machine is
      * unattached, we shouldn't assume the front-end knows this detail of the
      * Ubuntu Pro functionality.
      * Thus, if the front-end calls this function, we need to check if it is
      * attached lest the Get is attempted on a inexisting object. */
-    isAttached, err := isMachineProAttached(manager)
+    isAttached, err := s.isAttached()
     if err != nil {
         return false, err
     }
@@ -112,8 +112,8 @@ func isServiceEnabled(obj dbus.BusObject, manager dbus.BusObject) (bool, error) 
     return status.Value().(string) == "enabled", nil
 }
 
-func isMachineProAttached(manager dbus.BusObject) (bool, error) {
-    isAttached, err := manager.GetProperty("com.canonical.UbuntuAdvantage.Manager.Attached")
+func (s *ProServer) isAttached() (bool, error) {
+    isAttached, err := s.manager.GetProperty("com.canonical.UbuntuAdvantage.Manager.Attached")
     if err != nil {
         log.Println(err)
         return false, status.Errorf(codes.Internal, "%v", err)
@@ -123,7 +123,7 @@ func isMachineProAttached(manager dbus.BusObject) (bool, error) {
 
 /* Determines if system is attached to Ubuntu Pro. */
 func (s *ProServer) IsMachineProAttached(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    isAttached, err := isMachineProAttached(s.manager)
+    isAttached, err := s.isAttached()
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }
@@ -132,7 +132,7 @@ func (s *ProServer) IsMachineProAttached(ctx context.Context, _ *epb.Empty) (*wp
 
 /* Determines if the USG service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsUsgEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.usg, s.manager)
+    enabled, err := s.isServiceEnabled(s.usg)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }
@@ -141,7 +141,7 @@ func (s *ProServer) IsUsgEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolVa
 
 /* Determines if the FIPS service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsFipsEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.fips, s.manager)
+    enabled, err := s.isServiceEnabled(s.fips)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }
@@ -150,7 +150,7 @@ func (s *ProServer) IsFipsEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolV
 
 /* Determines if the ESM Infra service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsEsmInfraEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.infra, s.manager)
+    enabled, err := s.isServiceEnabled(s.infra)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }
@@ -159,7 +159,7 @@ func (s *ProServer) IsEsmInfraEnabled(ctx context.Context, _ *epb.Empty) (*wpb.B
 
 /* Determines if the ESM Apps service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsEsmAppsEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.apps, s.manager)
+    enabled, err := s.isServiceEnabled(s.apps)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }
@@ -168,7 +168,7 @@ func (s *ProServer) IsEsmAppsEnabled(ctx context.Context, _ *epb.Empty) (*wpb.Bo
 
 /* Determines if the Livepatch service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsKernelLivePatchEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.livepatch, s.manager)
+    enabled, err := s.isServiceEnabled(s.livepatch)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }

--- a/packages/backend/ubuntu-pro.go
+++ b/packages/backend/ubuntu-pro.go
@@ -132,7 +132,7 @@ func (s *ProServer) IsMachineProAttached(ctx context.Context, _ *epb.Empty) (*wp
 
 /* Determines if the USG service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsUsgEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.usg)
+    enabled, err := isServiceEnabled(s.usg, s.manager)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }
@@ -141,7 +141,7 @@ func (s *ProServer) IsUsgEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolVa
 
 /* Determines if the FIPS service of Ubuntu Pro is enabled. */
 func (s *ProServer) IsFipsEnabled(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
-    enabled, err := isServiceEnabled(s.fips)
+    enabled, err := isServiceEnabled(s.fips, s.manager)
     if err != nil {
         return nil, status.Errorf(codes.Internal, "%v", err)
     }

--- a/packages/backend/ubuntu-pro.go
+++ b/packages/backend/ubuntu-pro.go
@@ -124,6 +124,9 @@ func isMachineProAttached(manager dbus.BusObject) (bool, error) {
 /* Determines if system is attached to Ubuntu Pro. */
 func (s *ProServer) IsMachineProAttached(ctx context.Context, _ *epb.Empty) (*wpb.BoolValue, error) {
     isAttached, err := isMachineProAttached(s.manager)
+    if err != nil {
+        return nil, status.Errorf(codes.Internal, "%v", err)
+    }
     return wpb.Bool(isAttached), err
 }
 

--- a/packages/backend/ubuntu-pro_test.go
+++ b/packages/backend/ubuntu-pro_test.go
@@ -259,6 +259,14 @@ func TestIsServiceEnabled(t *testing.T) {
     require.NoError(t, err, err)
     require.Equal(t, i.GetValue(), false)
 
+	i, err = manager.proServer.IsUsgEnabled(ctx, nil)
+    require.NoError(t, err, err)
+    require.Equal(t, i.GetValue(), false)
+
+	i, err = manager.proServer.IsFipsEnabled(ctx, nil)
+    require.NoError(t, err, err)
+    require.Equal(t, i.GetValue(), false)
+
 	getResponseEnabled = "enabled"
 	i, err = manager.proServer.IsEsmInfraEnabled(ctx, nil)
     require.NoError(t, err, err)
@@ -272,6 +280,14 @@ func TestIsServiceEnabled(t *testing.T) {
     require.NoError(t, err, err)
     require.Equal(t, i.GetValue(), true)
 
+	i, err = manager.proServer.IsUsgEnabled(ctx, nil)
+    require.NoError(t, err, err)
+    require.Equal(t, i.GetValue(), true)
+
+	i, err = manager.proServer.IsFipsEnabled(ctx, nil)
+    require.NoError(t, err, err)
+    require.Equal(t, i.GetValue(), true)
+
 	getResponseEnabled = "error"
 	i, err = manager.proServer.IsEsmInfraEnabled(ctx, nil)
     require.Error(t, err, "Expected error, got nothing")
@@ -280,6 +296,12 @@ func TestIsServiceEnabled(t *testing.T) {
     require.Error(t, err, "Expected error, got nothing")
 
 	i, err = manager.proServer.IsKernelLivePatchEnabled(ctx, nil)
+    require.Error(t, err, "Expected error, got nothing")
+
+	i, err = manager.proServer.IsFipsEnabled(ctx, nil)
+    require.Error(t, err, "Expected error, got nothing")
+
+	i, err = manager.proServer.IsUsgEnabled(ctx, nil)
     require.Error(t, err, "Expected error, got nothing")
 }
 
@@ -394,6 +416,8 @@ func ExportAttachMock(conn *dbus.Conn) error {
 		"esm_2dapps",
 		"esm_2dinfra",
 		"livepatch",
+        "fips",
+        "usg",
 	} {
 		if err := conn.Export(a, dbus.ObjectPath("/com/canonical/UbuntuAdvantage/Services/"+val), "com.canonical.UbuntuAdvantage.Service"); err != nil {
 			return fmt.Errorf("could not export service mock: %w", err)


### PR DESCRIPTION
The front-end may call Is{Service}Enabled even if the machine is detached and this shouldn't cause an error. So make isServiceEnabled first check whether Ubuntu Pro is attached before actually trying to call the respective Dbus object.