### PR TITLE
feat: use long-polling to update the UI based on snapd's state

### DIFF
--- a/integration_test/security_center_test.dart
+++ b/integration_test/security_center_test.dart
@@ -7,6 +7,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:security_center/app_permissions/app_rules_page.dart';
 import 'package:security_center/app_permissions/snapd_interface.dart';
 import 'package:security_center/main.dart' as app;
+import 'package:security_center/services/snapd_service.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
@@ -86,7 +87,7 @@ List<SnapdRuleMask> getTestRules({String? snap, String? interface}) {
 
 Future<void> writeSnapdRules() async {
   final ruleMasks = getTestRules();
-  final snapd = SnapdClient();
+  final snapd = SnapdService();
   for (final rule in ruleMasks) {
     await snapd.addRule(rule);
   }
@@ -94,7 +95,7 @@ Future<void> writeSnapdRules() async {
 }
 
 Future<void> expectSnapdRules(List<SnapdRuleMask> rules) async {
-  final snapd = SnapdClient();
+  final snapd = SnapdService();
   final actual = await snapd.getRules();
   snapd.close();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:security_center/security_center_app.dart';
 import 'package:security_center/services/app_permissions_service.dart';
 import 'package:security_center/services/fake_app_permissions_service.dart';
 import 'package:security_center/services/snapd_app_permissions_service.dart';
-import 'package:snapd/snapd.dart';
+import 'package:security_center/services/snapd_service.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
@@ -36,9 +36,9 @@ Future<void> main(List<String> args) async {
     exit(2);
   }
 
-  registerService<SnapdClient>(SnapdClient.new);
+  registerService<SnapdService>(SnapdService.new);
 
-  final snapMetadata = await getService<SnapdClient>().getSnaps();
+  final snapMetadata = await getService<SnapdService>().getSnaps();
   registerServiceInstance<LocalSnapData>(snapMetadata);
 
   if (argResults.flag('dry-run')) {
@@ -51,7 +51,7 @@ Future<void> main(List<String> args) async {
   } else {
     registerService<AppPermissionsService>(
       () => SnapdAppPermissionsService(
-        getService<SnapdClient>(),
+        getService<SnapdService>(),
       )..init(),
       dispose: (service) => service.dispose(),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,13 +45,15 @@ Future<void> main(List<String> args) async {
     registerService<AppPermissionsService>(
       () => FakeAppPermissionsService.fromFile(
         argResults['test-rules'] as String,
-      ),
+      )..init(),
+      dispose: (service) => service.dispose(),
     );
   } else {
     registerService<AppPermissionsService>(
       () => SnapdAppPermissionsService(
         getService<SnapdClient>(),
-      ),
+      )..init(),
+      dispose: (service) => service.dispose(),
     );
   }
   runApp(const ProviderScope(child: SecurityCenterApp()));

--- a/lib/services/app_permissions_service.dart
+++ b/lib/services/app_permissions_service.dart
@@ -13,7 +13,7 @@ part 'app_permissions_service.freezed.dart';
 
 @freezed
 sealed class AppPermissionsServiceStatus with _$AppPermissionsServiceStatus {
-  factory AppPermissionsServiceStatus.enabled() =
+  factory AppPermissionsServiceStatus.enabled(List<SnapdRule> rules) =
       AppPermissionsServiceStatusEnabled;
   factory AppPermissionsServiceStatus.disabled() =
       AppPermissionsServiceStatusDisabled;
@@ -33,15 +33,13 @@ sealed class AppPermissionsServiceStatus with _$AppPermissionsServiceStatus {
 }
 
 abstract class AppPermissionsService {
-  Future<List<SnapdRule>> getRules({
-    String? snap,
-    String? interface,
-  });
+  Future<void> init();
+  Future<void> dispose();
 
+  Stream<AppPermissionsServiceStatus> get status;
+
+  Future<void> enable();
+  Future<void> disable();
   Future<void> removeRule(String id);
   Future<void> removeAllRules({required String snap, String? interface});
-
-  Future<bool> isEnabled();
-  Stream<AppPermissionsServiceStatus> enable();
-  Stream<AppPermissionsServiceStatus> disable();
 }

--- a/lib/services/app_permissions_service.dart
+++ b/lib/services/app_permissions_service.dart
@@ -25,6 +25,8 @@ sealed class AppPermissionsServiceStatus with _$AppPermissionsServiceStatus {
       AppPermissionsServiceStatusDisabling;
   factory AppPermissionsServiceStatus.waitingForAuth() =
       AppPermissionsServiceStatusWaitingForAuth;
+  factory AppPermissionsServiceStatus.waitingForSnapd() =
+      AppPermissionsServiceStatusWaitingForSnapd;
 
   AppPermissionsServiceStatus._();
 

--- a/lib/services/fake_app_permissions_service.dart
+++ b/lib/services/fake_app_permissions_service.dart
@@ -48,11 +48,6 @@ class FakeAppPermissionsService implements AppPermissionsService {
   }
 
   @override
-  Future<void> dispose() async {
-    await _statusController.close();
-  }
-
-  @override
   Future<void> init() async {
     _statusController = StreamController<AppPermissionsServiceStatus>.broadcast(
       onListen: () async {
@@ -60,6 +55,11 @@ class FakeAppPermissionsService implements AppPermissionsService {
         _statusController.add(AppPermissionsServiceStatus.enabled(rules));
       },
     );
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _statusController.close();
   }
 
   @override

--- a/lib/services/snapd_app_permissions_service.dart
+++ b/lib/services/snapd_app_permissions_service.dart
@@ -137,8 +137,12 @@ class SnapdAppPermissionsService implements AppPermissionsService {
       }
       await _updateStatus();
     } on SnapdException catch (e) {
-      _log.error('Error: $e');
-      _emitStatus(AppPermissionsServiceStatus.error(e));
+      if (e.kind == 'auth-cancelled') {
+        await _updateStatus();
+      } else {
+        _log.error('Error: $e');
+        _emitStatus(AppPermissionsServiceStatus.error(e));
+      }
     }
   }
 

--- a/lib/services/snapd_app_permissions_service.dart
+++ b/lib/services/snapd_app_permissions_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:security_center/app_permissions/rules_providers.dart';
 import 'package:security_center/services/app_permissions_service.dart';
@@ -80,7 +81,13 @@ class SnapdAppPermissionsService implements AppPermissionsService {
           await _client.getNotices(after: DateTime.now(), timeout: '10ms');
           _emitStatus(AppPermissionsServiceStatus.disabled());
         } else {
-          final rules = await _client.getRules();
+          final rules = await _client.getRules().onError(
+            (e, __) {
+              _log.error('Error while fetching rules: $e');
+              return [];
+            },
+            test: (e) => e is HttpException,
+          );
           _emitStatus(AppPermissionsServiceStatus.enabled(rules));
         }
         break;

--- a/lib/services/snapd_service.dart
+++ b/lib/services/snapd_service.dart
@@ -1,0 +1,11 @@
+import 'package:snapd/snapd.dart';
+
+class SnapdService extends SnapdClient {
+  Stream<SnapdChange> watchChange(
+    String id, {
+    Duration interval = const Duration(milliseconds: 100),
+  }) =>
+      Stream.periodic(interval, (_) => getChange(id))
+          .asyncMap((response) async => response)
+          .distinct();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -781,10 +781,10 @@ packages:
     dependency: "direct main"
     description:
       name: snapd
-      sha256: "44adefb84edc957b70006cb893caf0cf442268a64279b9b15b35184ead6628f4"
+      sha256: da7575a196f84a6e653adb2949ad8d11ebf6ef77cd4f5a7fd21ffd435aeca6ec
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path: ^1.9.0
   riverpod: ^2.5.1
   riverpod_annotation: ^2.3.5
-  snapd: ^0.6.2
+  snapd: 0.6.4
   ubuntu_localizations: ^0.3.0
   ubuntu_logger: ^0.1.1
   ubuntu_service: ^0.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path: ^1.9.0
   riverpod: ^2.5.1
   riverpod_annotation: ^2.3.5
-  snapd: 0.6.4
+  snapd: ^0.6.4
   ubuntu_localizations: ^0.3.0
   ubuntu_logger: ^0.1.1
   ubuntu_service: ^0.3.2

--- a/test/app_permissions/app_rules_page_test.dart
+++ b/test/app_permissions/app_rules_page_test.dart
@@ -11,7 +11,7 @@ import '../test_utils.dart';
 void main() {
   testWidgets('display and delete rules', (tester) async {
     final container = createContainer();
-    final mockRulesService = registerMockRulesService(
+    final mockRulesService = registerMockAppPermissionsService(
       rules: [
         SnapdRule(
           id: 'ruleId',
@@ -60,7 +60,7 @@ void main() {
 
   testWidgets('no rules', (tester) async {
     final container = createContainer();
-    registerMockRulesService();
+    registerMockAppPermissionsService();
     registerMockLocalSnapData();
     await tester.pumpApp(
       (_) => UncontrolledProviderScope(

--- a/test/app_permissions/interfaces_page_test.dart
+++ b/test/app_permissions/interfaces_page_test.dart
@@ -26,7 +26,7 @@ void main() {
         ),
       ],
     );
-    registerMockSnapdClient();
+    registerMockSnapdService();
     await tester.pumpApp(
       (_) => UncontrolledProviderScope(
         container: container,

--- a/test/app_permissions/interfaces_page_test.dart
+++ b/test/app_permissions/interfaces_page_test.dart
@@ -13,7 +13,7 @@ import '../test_utils.dart';
 void main() {
   testWidgets('display interfaces', (tester) async {
     final container = createContainer();
-    registerMockRulesService(
+    registerMockAppPermissionsService(
       rules: [
         SnapdRule(
           id: 'ruleId',
@@ -26,6 +26,7 @@ void main() {
         ),
       ],
     );
+    registerMockSnapdClient();
     await tester.pumpApp(
       (_) => UncontrolledProviderScope(
         container: container,
@@ -68,7 +69,8 @@ void main() {
       ]) {
         testWidgets(testCase.name, (tester) async {
           final container = createContainer();
-          final service = registerMockRulesService(enabled: testCase.enabled);
+          final service =
+              registerMockAppPermissionsService(enabled: testCase.enabled);
           await tester.pumpApp(
             (_) => UncontrolledProviderScope(
               container: container,
@@ -119,7 +121,7 @@ void main() {
       ]) {
         testWidgets(testCase.name, (tester) async {
           final container = createContainer();
-          registerMockRulesService();
+          registerMockAppPermissionsService();
           await tester.pumpApp(
             (_) => UncontrolledProviderScope(
               container: container,

--- a/test/app_permissions/snaps_page_test.dart
+++ b/test/app_permissions/snaps_page_test.dart
@@ -10,7 +10,7 @@ import '../test_utils.dart';
 void main() {
   testWidgets('display snaps', (tester) async {
     final container = createContainer();
-    registerMockRulesService(
+    registerMockAppPermissionsService(
       rules: [
         SnapdRule(
           id: 'ruleId',

--- a/test/services/snapd_app_permissions_service_test.dart
+++ b/test/services/snapd_app_permissions_service_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:security_center/services/app_permissions_service.dart';
+import 'package:security_center/services/snapd_app_permissions_service.dart';
+import 'package:snapd/snapd.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  final testRules = [
+    SnapdRule(
+      id: 'ruleId',
+      timestamp: DateTime(2024),
+      snap: 'firefox',
+      interface: 'home',
+      constraints: const SnapdConstraints(),
+      outcome: SnapdRequestOutcome.allow,
+      lifespan: SnapdRequestLifespan.forever,
+    ),
+  ];
+  final testNotice = SnapdNotice(
+    id: '1',
+    type: SnapdNoticeType.interfacesRequestsRuleUpdate,
+    key: '101',
+    firstOccured: DateTime(2000),
+    lastOccured: DateTime(2001),
+    lastRepeated: DateTime(2001),
+    occurrences: 1,
+    expireAfter: '',
+  );
+  group('status stream', () {
+    final testCases = <({
+      String name,
+      List<NoticesEvent> noticeEvents,
+      List<AppPermissionsServiceStatus> expectedStatuses
+    })>[
+      (
+        name: 'successful rule update',
+        noticeEvents: [
+          NoticesEvent.success([testNotice]),
+        ],
+        expectedStatuses: [
+          AppPermissionsServiceStatus.enabled(testRules),
+        ],
+      ),
+      (
+        name: 'empty notices don\'t change status',
+        noticeEvents: [
+          NoticesEvent.success([testNotice]),
+          NoticesEvent.success([]),
+        ],
+        expectedStatuses: [
+          AppPermissionsServiceStatus.enabled(testRules),
+        ],
+      ),
+      (
+        name: 'retry after error',
+        noticeEvents: [
+          NoticesEvent.success([testNotice]),
+          NoticesEvent.error(SnapdException(message: 'error')),
+          NoticesEvent.success([testNotice]),
+        ],
+        expectedStatuses: [
+          AppPermissionsServiceStatus.enabled(testRules),
+        ],
+      ),
+    ];
+
+    for (final testCase in testCases) {
+      test(testCase.name, () async {
+        final service = SnapdAppPermissionsService(
+          registerMockSnapdService(
+            noticesEvents: testCase.noticeEvents,
+            rules: testRules,
+          ),
+        );
+        await service.init();
+        addTearDown(service.dispose);
+
+        await expectLater(
+          service.status,
+          emitsInOrder(testCase.expectedStatuses),
+        );
+      });
+    }
+  });
+
+  group('toggling prompting feature', () {
+    final testCases = <({
+      String name,
+      bool enabled,
+      Future<void> Function(AppPermissionsService) callback,
+      List<AppPermissionsServiceStatus> expectedStatuses
+    })>[
+      (
+        name: 'enable',
+        enabled: true,
+        callback: (service) => service.enable(),
+        expectedStatuses: [
+          AppPermissionsServiceStatus.waitingForAuth(),
+          AppPermissionsServiceStatus.enabling(0.0),
+          AppPermissionsServiceStatus.enabling(0.5),
+          AppPermissionsServiceStatus.enabled([]),
+        ],
+      ),
+      (
+        name: 'disable',
+        enabled: false,
+        callback: (service) => service.disable(),
+        expectedStatuses: [
+          AppPermissionsServiceStatus.waitingForAuth(),
+          AppPermissionsServiceStatus.disabling(0.0),
+          AppPermissionsServiceStatus.disabling(0.5),
+          AppPermissionsServiceStatus.disabled(),
+        ],
+      ),
+    ];
+
+    for (final testCase in testCases) {
+      test(testCase.name, () async {
+        final service = SnapdAppPermissionsService(
+          registerMockSnapdService(
+            promptingEnabled: testCase.enabled,
+            changeId: 'changeId',
+            changes: const [
+              SnapdChange(
+                id: 'changeId',
+                tasks: [
+                  SnapdTask(
+                    id: 'taskId',
+                    progress: SnapdTaskProgress(done: 1, total: 2),
+                  ),
+                ],
+              ),
+              SnapdChange(
+                id: 'changeId',
+                ready: true,
+                tasks: [
+                  SnapdTask(
+                    id: 'taskId',
+                    progress: SnapdTaskProgress(done: 2, total: 2),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+        await service.init();
+        addTearDown(service.dispose);
+        service.status.listen(
+          (status) =>
+              expect(status, equals(testCase.expectedStatuses.removeAt(0))),
+        );
+
+        await testCase.callback(service);
+      });
+    }
+  });
+}

--- a/test/services/snapd_app_permissions_service_test.dart
+++ b/test/services/snapd_app_permissions_service_test.dart
@@ -89,12 +89,14 @@ void main() {
       String name,
       bool enabled,
       Future<void> Function(AppPermissionsService) callback,
+      bool authCancelled,
       List<AppPermissionsServiceStatus> expectedStatuses
     })>[
       (
         name: 'enable',
         enabled: true,
         callback: (service) => service.enable(),
+        authCancelled: false,
         expectedStatuses: [
           AppPermissionsServiceStatus.waitingForAuth(),
           AppPermissionsServiceStatus.enabling(0.0),
@@ -106,10 +108,21 @@ void main() {
         name: 'disable',
         enabled: false,
         callback: (service) => service.disable(),
+        authCancelled: false,
         expectedStatuses: [
           AppPermissionsServiceStatus.waitingForAuth(),
           AppPermissionsServiceStatus.disabling(0.0),
           AppPermissionsServiceStatus.disabling(0.5),
+          AppPermissionsServiceStatus.disabled(),
+        ],
+      ),
+      (
+        name: 'auth cancelled',
+        enabled: false,
+        callback: (service) => service.enable(),
+        authCancelled: true,
+        expectedStatuses: [
+          AppPermissionsServiceStatus.waitingForAuth(),
           AppPermissionsServiceStatus.disabled(),
         ],
       ),
@@ -142,6 +155,7 @@ void main() {
                 ],
               ),
             ],
+            authCancelled: testCase.authCancelled,
           ),
         );
         await service.init();

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:security_center/app_permissions/snap_metadata_providers.dart';
 import 'package:security_center/l10n.dart';
 import 'package:security_center/services/app_permissions_service.dart';
+import 'package:security_center/services/snapd_service.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
@@ -74,11 +75,12 @@ LocalSnapData registerMockLocalSnapData({
   return snaps;
 }
 
-@GenerateMocks([SnapdClient])
-SnapdClient registerMockSnapdClient({
+@GenerateMocks([SnapdService])
+SnapdService registerMockSnapdService({
   List<SnapdNotice> notices = const [],
 }) {
-  final client = MockSnapdClient();
+  final client = MockSnapdService();
+
   when(
     client.getNotices(
       types: anyNamed('types'),
@@ -87,7 +89,7 @@ SnapdClient registerMockSnapdClient({
     ),
   ).thenAnswer((_) async => notices);
 
-  registerServiceInstance<SnapdClient>(client);
-  addTearDown(unregisterService<SnapdClient>);
+  registerServiceInstance<SnapdService>(client);
+  addTearDown(unregisterService<SnapdService>);
   return client;
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -48,15 +48,18 @@ ProviderContainer createContainer({
 }
 
 @GenerateMocks([AppPermissionsService])
-AppPermissionsService registerMockRulesService({
+AppPermissionsService registerMockAppPermissionsService({
   List<SnapdRule> rules = const [],
   bool enabled = true,
 }) {
   final service = MockAppPermissionsService();
-  when(service.getRules()).thenAnswer((_) async => rules);
-  when(service.isEnabled()).thenAnswer((_) async => enabled);
-  when(service.enable()).thenAnswer((_) => const Stream.empty());
-  when(service.disable()).thenAnswer((_) => const Stream.empty());
+  when(service.status).thenAnswer(
+    (_) => Stream.value(
+      enabled
+          ? AppPermissionsServiceStatus.enabled(rules)
+          : AppPermissionsServiceStatus.disabled(),
+    ),
+  );
 
   registerMockService<AppPermissionsService>(service);
   addTearDown(unregisterService<AppPermissionsService>);
@@ -69,4 +72,22 @@ LocalSnapData registerMockLocalSnapData({
   registerServiceInstance<LocalSnapData>(snaps);
   addTearDown(unregisterService<LocalSnapData>);
   return snaps;
+}
+
+@GenerateMocks([SnapdClient])
+SnapdClient registerMockSnapdClient({
+  List<SnapdNotice> notices = const [],
+}) {
+  final client = MockSnapdClient();
+  when(
+    client.getNotices(
+      types: anyNamed('types'),
+      after: anyNamed('after'),
+      timeout: anyNamed('timeout'),
+    ),
+  ).thenAnswer((_) async => notices);
+
+  registerServiceInstance<SnapdClient>(client);
+  addTearDown(unregisterService<SnapdClient>);
+  return client;
 }


### PR DESCRIPTION
Automatically updates the UI when
* the prompting feature is toggled externally
* prompting rules change

This also includes some retry logic to gracefully handle snapd errors while it's restarting when the feature flag is toggled

[Screencast from 2024-08-23 13-58-16.webm](https://github.com/user-attachments/assets/fcb97f90-b346-40e4-9691-b86e76b526c3)

~~The UI change is a bit delayed when the feature is toggled externally, I'll see if I can add a loading state or at least disable the toggle button for that case.~~

Added a `waitingForSnapd` state

[Screencast from 2024-08-23 14-31-18.webm](https://github.com/user-attachments/assets/809b3d01-a20e-4b22-a601-d59d86045410)



UDENG-3790
UDENG-4077