### PR TITLE
fix(snapcraft): add network plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ apps:
     command: bin/security_center
     extensions: [gnome]
     plugs:
+      - network
       - snapd-control
 
 parts:


### PR DESCRIPTION
This is needed to fetch snap icons from the store.

Note: sometimes icons are still missing due to snapd not returning URLs in requests to `/v2/snaps`. I still can't reliably reproduce the issue though - will open an issue once I know more.