### PR TITLE
fix(snapcraft): rename security center app

### DIFF
--- a/snap/gui/desktop-security-center.desktop
+++ b/snap/gui/desktop-security-center.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Exec=desktop-security-center.security-center %U
+Exec=desktop-security-center %U
 Icon=${SNAP}/meta/gui/desktop-security-center.png
 Terminal=false
 Categories=System;Utility;Permissions;Settings;Security;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 compression: lzo
 
 apps:
-  security-center:
+  desktop-security-center:
     command: bin/security_center
     extensions: [gnome]
     plugs:


### PR DESCRIPTION
Renames the `app` in the snapcraft.yaml to match the snap name (see [docs](https://snapcraft.io/docs/snapcraft-yaml-reference#appsapp-name)). This seems to fix the issue where the icon and translated name aren't correctly displayed in the dock.

UDENG-4336