### PR TITLE
fix: match Figma for empty rules UI state

### DIFF
--- a/packages/security_center/lib/app_permissions/app_rules_page.dart
+++ b/packages/security_center/lib/app_permissions/app_rules_page.dart
@@ -6,6 +6,7 @@ import 'package:security_center/app_permissions/snap_metadata_providers.dart';
 import 'package:security_center/app_permissions/snapd_interface.dart';
 import 'package:security_center/l10n.dart';
 import 'package:security_center/widgets/app_icon.dart';
+import 'package:security_center/widgets/empty_rules_tile.dart';
 import 'package:security_center/widgets/scrollable_page.dart';
 import 'package:security_center/widgets/tile_list.dart';
 import 'package:yaru/yaru.dart';
@@ -70,7 +71,7 @@ class _Body extends ConsumerWidget {
         if (rules.isEmpty) ...[
           const TileList(
             children: [
-              _EmptyRuleTile(),
+              EmptyRulesTile(),
             ],
           ),
           const SizedBox(height: 24),
@@ -166,20 +167,6 @@ class RuleTile extends StatelessWidget {
         icon: const Icon(YaruIcons.window_close),
         onPressed: onRemove,
       ),
-    );
-  }
-}
-
-class _EmptyRuleTile extends StatelessWidget {
-  const _EmptyRuleTile();
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      title: Center(
-        child: Text(AppLocalizations.of(context).snapRulesPageEmptyTileLabel),
-      ),
-      enabled: false,
     );
   }
 }

--- a/packages/security_center/lib/app_permissions/interfaces_page.dart
+++ b/packages/security_center/lib/app_permissions/interfaces_page.dart
@@ -152,8 +152,11 @@ class _InterfaceList extends ConsumerWidget {
                     contentPadding: const EdgeInsets.all(16),
                     leading: Icon(interfaceSnapCount.key.icon, size: 48),
                     title: Text(interfaceSnapCount.key.localizedTitle(l10n)),
-                    subtitle:
-                        Text(l10n.interfaceSnapCount(interfaceSnapCount.value)),
+                    subtitle: Text(
+                      interfaceSnapCount.value > 0
+                          ? l10n.interfaceSnapCount(interfaceSnapCount.value)
+                          : l10n.snapRulesPageEmptyTileLabel,
+                    ),
                     trailing: const Icon(YaruIcons.pan_end),
                     onTap: () => Navigator.of(context)
                         .pushSnapPermissions(interface: interfaceSnapCount.key),

--- a/packages/security_center/lib/app_permissions/rules_providers.dart
+++ b/packages/security_center/lib/app_permissions/rules_providers.dart
@@ -33,7 +33,7 @@ Future<Map<SnapdInterface, int>> interfaceSnapCounts(
 ) async {
   final rules = await ref.watch(rulesProvider.future);
   final interfaceSnaps = rules.fold<Map<String, Set<String>>>(
-    {},
+    {'home': {}},
     (snaps, rule) {
       snaps[rule.interface] = (snaps[rule.interface] ?? {})..add(rule.snap);
       return snaps;

--- a/packages/security_center/lib/app_permissions/snaps_page.dart
+++ b/packages/security_center/lib/app_permissions/snaps_page.dart
@@ -6,6 +6,7 @@ import 'package:security_center/app_permissions/snapd_interface.dart';
 import 'package:security_center/l10n.dart';
 import 'package:security_center/navigator.dart';
 import 'package:security_center/widgets/app_icon.dart';
+import 'package:security_center/widgets/empty_rules_tile.dart';
 import 'package:security_center/widgets/scrollable_page.dart';
 import 'package:security_center/widgets/tile_list.dart';
 import 'package:yaru/yaru.dart';
@@ -58,7 +59,7 @@ class _Body extends ConsumerWidget {
         const SizedBox(height: 12),
         Text(interface.localizedDescription(l10n)),
         const SizedBox(height: 24),
-        TileList(children: tiles),
+        TileList(children: tiles.isEmpty ? [const EmptyRulesTile()] : tiles),
       ],
     );
   }

--- a/packages/security_center/lib/widgets/empty_rules_tile.dart
+++ b/packages/security_center/lib/widgets/empty_rules_tile.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:security_center/l10n.dart';
+
+class EmptyRulesTile extends StatelessWidget {
+  const EmptyRulesTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Center(
+        child: Text(AppLocalizations.of(context).snapRulesPageEmptyTileLabel),
+      ),
+      enabled: false,
+    );
+  }
+}


### PR DESCRIPTION
[Screencast from 2024-09-06 16-57-18.webm](https://github.com/user-attachments/assets/b5ecb405-a4ed-41e0-88ab-8ba184618967)

Fixes the last two points from https://github.com/canonical/desktop-security-center/issues/50#issuecomment-2317621431

UDENG-4441