### PR TITLE
fix: 'snaps'->'apps' in feature switch label

### DIFF
--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -16,7 +16,7 @@
     "@snapPermissionWriteLabel": {},
     "snapPermissionExecuteLabel": "Execute",
     "@snapPermissionExecuteLabel": {},
-    "snapPermissionsEnableTitle": "Require snaps to ask for system permissions",
+    "snapPermissionsEnableTitle": "Require apps to ask for system permissions",
     "@snapPermissionsEnableTitle": {},
     "snapPermissionsEnableWarning": "This is an experimental feature for controlling access to your system’s resources.",
     "@snapPermissionsEnableWarning": {},


### PR DESCRIPTION
Fix #60
UDENG-4492