### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report for the Security Center
 description: Create a report to help us improve
-title: "[Bug]: "
 labels:
   - bug
 assignees:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report for the Security Center
+description: Create a report to help us improve
+title: "[Bug]: "
+labels:
+  - bug
+assignees:
+  - d-loose
+  - juanruitina
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: |
+      Please search to see if an issue already exists for this feature: https://github.com/canonical/desktop-security-center/issues.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: |
+      A clear and concise description of what the bug is.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps to reproduce the behavior
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: false
+- type: textarea
+  id: expected_behavior
+  attributes:
+    label: Expected behavior
+    description: |
+      A clear and concise description of what you expected to happen.
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: Ubuntu release
+    description: What version of our Ubuntu are you running?
+    options:
+      - '24.10'
+      - 24.04 LTS
+      - Other (specify in the last field)
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: What architecture are you using?
+    multiple: false
+    options:
+      - amd64
+      - arm64
+      - Other (specify in the last field)
+      - I don't know
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      Provide any additional context that may be relevant to the feature request. You can attach screenshots, logs (remember to anonymize!), or any other information that you think might be helpful.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
   attributes:
     label: Describe the bug
     description: |
-      A clear and concise description of what the bug is.
+      A clear and concise description of what the bug is. You can also attach screenshots or recordings.
   validations:
     required: false
 - type: textarea
@@ -65,6 +65,6 @@ body:
   attributes:
     label: Additional context
     description: |
-      Provide any additional context that may be relevant to the feature request. You can attach screenshots, logs (remember to anonymize!), or any other information that you think might be helpful.
+      You can attach screenshots, recordings, logs (remember to anonymize!), or any other information that you think might be helpful.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -1,8 +1,8 @@
 name: Bug report for App Permissions prompts
 description: Issues with prompts and specific apps? Let us know.
-title: "[Prompting bug]: "
 labels:
   - bug
+  - prompting
 assignees:
   - sminez
   - juanruitina

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -1,0 +1,76 @@
+name: Bug report for App Permissions prompts
+description: Issues with prompts and specific apps? Let us know.
+title: "[Prompting bug]: "
+labels:
+  - bug
+assignees:
+  - sminez
+  - juanruitina
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: |
+      Please search to see if an issue already exists for this feature: https://github.com/canonical/desktop-security-center/issues.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: |
+      A clear and concise description of what the bug is.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps to reproduce the behavior
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: false
+- type: textarea
+  id: expected_behavior
+  attributes:
+    label: Expected behavior
+    description: |
+      A clear and concise description of what you expected to happen.
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: Ubuntu release
+    description: What version of our Ubuntu are you running?
+    options:
+      - '24.10'
+      - 24.04 LTS
+      - Other (specify in the last field)
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: What architecture are you using?
+    multiple: false
+    options:
+      - amd64
+      - arm64
+      - Other (specify in the last field)
+      - I don't know
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: App or apps where you encountered the issue
+    description: Remember only [strictly confined snaps](https://snapcraft.io/docs/snap-confinement) are covered by App Permissions. Apps from the App Center are snaps. Debs, Flatpaks and AppImages are not.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      Provide any additional context that may be relevant to the feature request. You can attach screenshots, logs (remember to anonymize!), or any other information that you think might be helpful.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -19,7 +19,7 @@ body:
   attributes:
     label: Describe the bug
     description: |
-      A clear and concise description of what the bug is.
+      A clear and concise description of what the bug is. You can also attach screenshots or recordings.
   validations:
     required: false
 - type: textarea
@@ -71,6 +71,6 @@ body:
   attributes:
     label: Additional context
     description: |
-      Provide any additional context that may be relevant to the feature request. You can attach screenshots, logs (remember to anonymize!), or any other information that you think might be helpful.
+      You can attach screenshots, recordings, logs (remember to anonymize!), or any other information that you think might be helpful.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Give feedback about App Permissions
+    url: https://t.maze.co/266411709?guerilla=true&source=github
+    about: Share your overall experience and help us improve the feature by filling our survey

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an idea for the Security Center
+assignees:
+  - juanruitina
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: |
+      Please search to see if an issue already exists for this feature: https://github.com/canonical/steam-snap/issues?q=label%3Aenhancement.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Is the feature related to a problem or existing issue?
+    description: |
+      If so, please describe the problem or reference/link the issue number. If not, leave this empty.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Describe the solution/feature you'd like.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe any alternatives you've considered.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      Provide any additional context that may be relevant to the feature request.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,7 @@
 name: Feature request
 description: Suggest an idea for the Security Center
+labels:
+  - feature-request
 assignees:
   - juanruitina
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for the Security Center
 labels:
-  - feature-request
+  - enhancement
 assignees:
   - juanruitina
 body:


### PR DESCRIPTION
* Add separate form templates for prompting bug reporting, Security Center bug reporting, feature requests (to see how it works live see: https://github.com/juanruitina/issue-templates/issues/new/choose)
* Add link to prompting survey.
* Assign issues automatically

UDENG-4333