### PR TITLE
feat: check if prompting feature is supported

### DIFF
--- a/packages/security_center/lib/main.dart
+++ b/packages/security_center/lib/main.dart
@@ -15,7 +15,7 @@ import 'package:yaru/yaru.dart';
 
 Future<void> main(List<String> args) async {
   await YaruWindowTitleBar.ensureInitialized();
-  Logger.setup(path: '', level: LogLevel.info);
+  Logger.setup(path: '');
 
   final parser = ArgParser()
     ..addFlag(

--- a/packages/security_center/lib/services/app_permissions_service.dart
+++ b/packages/security_center/lib/services/app_permissions_service.dart
@@ -27,6 +27,8 @@ sealed class AppPermissionsServiceStatus with _$AppPermissionsServiceStatus {
       AppPermissionsServiceStatusWaitingForAuth;
   factory AppPermissionsServiceStatus.waitingForSnapd() =
       AppPermissionsServiceStatusWaitingForSnapd;
+  factory AppPermissionsServiceStatus.unavailable() =
+      AppPermissionsServiceStatusUnavailable;
 
   AppPermissionsServiceStatus._();
 

--- a/packages/security_center/test/test_utils.dart
+++ b/packages/security_center/test/test_utils.dart
@@ -83,6 +83,7 @@ SnapdService registerMockSnapdService({
   List<NoticesEvent> noticesEvents = const [],
   List<SnapdRule> rules = const [],
   bool promptingEnabled = true,
+  bool promptingSupported = true,
   String changeId = '',
   List<SnapdChange> changes = const [],
   bool authCancelled = false,
@@ -113,7 +114,10 @@ SnapdService registerMockSnapdService({
     (_) async => SnapdSystemInfoResponse(
       refresh: SnapdSystemRefreshInfo(next: DateTime(1970)),
       features: {
-        'apparmor-prompting': {'enabled': promptingEnabled},
+        'apparmor-prompting': {
+          'enabled': promptingEnabled,
+          'supported': promptingSupported,
+        },
       },
     ),
   );


### PR DESCRIPTION
Checks whether the currently installed snapd version supports apparmor prompting and disables the toggle button if that's not the case.

Also: I've removed the hardcoded log level, so it can be changed via the environment and added some useful debug logs.

UDENG-4493