### PR TITLE
fix: Fixing issue with libhandy on non-GNOME x11

### DIFF
--- a/packages/security_center/linux/my_application.cc
+++ b/packages/security_center/linux/my_application.cc
@@ -1,9 +1,7 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
+#include <handy.h>
 
 #include "flutter/generated_plugin_registrant.h"
 
@@ -17,35 +15,9 @@ G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
-  GtkWindow* window =
-      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "security_center");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "security_center");
-  }
+  GtkWindow* window = GTK_WINDOW(hdy_application_window_new());
+  gtk_window_set_application(window, GTK_APPLICATION(application));
 
   GdkGeometry geometry;
   geometry.min_width = 800 + 52;
@@ -53,16 +25,16 @@ static void my_application_activate(GApplication* application) {
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
 
   gtk_window_set_default_size(window, 800+52, 600+52);
+  gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
 
   FlView* view = fl_view_new(project);
+  gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
-  gtk_widget_show(GTK_WIDGET(window));
-  gtk_widget_show(GTK_WIDGET(view));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }


### PR DESCRIPTION
Modifying the way we set up the GTK window using libhandy to match how things are done in the app-center. The commit that set things up in the app-center can be found here:
  https://github.com/ubuntu/app-center/commit/43e7ae0a6ce82706b77587899ad06c36a2fac781

Note that this is _not_ how [the docs for the handy_window package](https://pub.dev/packages/handy_window#usage) tell you to set things up (this is what we followed originally). Prior to this change we tested the current code under multiple desktop environments on Ubuntu 24.04 with the following results:

  - GNOME classic Wayland: works
  - GNOME classic X11: works
  - Ubuntu desktop Wayland: works
  - Ubuntu desktop X11: works
  - Penrose X11: uninitialised window, closing leave the process running and eating CPU.
  - i3: uninitialised window, closing leave the process running and eating CPU.

With the change all of the above desktop environments work as expected.

> The above are tested on an AMD Framework 13

---

:warning: **We will need to make an equivalent change to the firmware updater as well** :warning: 

---

@robert-ancell: Dennis and I spent the morning getting to the bottom of this and while we are confident that this PR fixes the issue we're not 100% on what the underlying problem is, particularly as the existing code _does_ work under GNOME on X11. Any ideas?