### PR TITLE
feat: link to new issue templates on 'report issues'

### DIFF
--- a/packages/security_center/lib/app_permissions/interfaces_page.dart
+++ b/packages/security_center/lib/app_permissions/interfaces_page.dart
@@ -60,7 +60,7 @@ enum _Link {
         giveFeedback =>
           'https://t.maze.co/266411709?guerilla=true&source=securitycenter',
         reportIssues =>
-          'https://github.com/canonical/desktop-security-center/issues/new',
+          'https://github.com/canonical/desktop-security-center/issues/new/choose',
       };
   String localize(AppLocalizations l10n) => switch (this) {
         learnMore => l10n.interfacePageLinkLearnMore,


### PR DESCRIPTION
This makes sure we point users that click on the 'report issue' link to the new templates.
