### PR TITLE
feat: Add system  info to GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,8 +62,17 @@ body:
     required: false
 - type: textarea
   attributes:
+    label: System info
+    description: |
+      Please run this command in your terminal:
+      ```uname -rv && snap info snapd prompting-client desktop-security-center```
+      and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
+  validations:
+    required: false
+- type: textarea
+  attributes:
     label: Additional context
     description: |
-      You can attach screenshots, recordings, logs (remember to anonymize!), or any other information that you think might be helpful.
+      You can attach screenshots, recordings, logs, or any other information that you think might be helpful. Please remember to anonymize any personal data.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -71,7 +71,9 @@ body:
   attributes:
     label: System info
     description: |
-      Please run this command in your terminal: `uname -rv && snap info snapd prompting-client desktop-security-center` and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
+      Please run this command in your terminal:
+      ```uname -rv && snap info snapd prompting-client desktop-security-center```
+      and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -69,6 +69,13 @@ body:
     required: false
 - type: textarea
   attributes:
+    label: System info
+    description: |
+      Please run this command in your terminal: `uname -rv && snap info snapd prompting-client desktop-security-center` and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
+  validations:
+    required: false
+- type: textarea
+  attributes:
     label: Additional context
     description: |
       You can attach screenshots, recordings, logs (remember to anonymize!), or any other information that you think might be helpful.

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -80,7 +80,7 @@ body:
   attributes:
     label: Additional context
     description: |
-      You can attach screenshots, recordings, or any other information that you think might be helpful. You can also paste logs that seem relevant: you can get them running this command in your terminal: 
+      You can attach screenshots, recordings, or any other information that you think might be helpful. You can also paste logs that seem relevant: you can get them by running this command in your terminal: 
       ```journalctl --user | grep prompting-client.daemon```
       Please remember to anonymize any personal data.
   validations:

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -61,12 +61,6 @@ body:
       - I don't know
   validations:
     required: false
-- type: input
-  attributes:
-    label: App or apps where you encountered the issue
-    description: Remember only [strictly confined snaps](https://snapcraft.io/docs/snap-confinement) are covered by App Permissions. Apps from the App Center are snaps. Debs, Flatpaks and AppImages are not.
-  validations:
-    required: false
 - type: textarea
   attributes:
     label: System info
@@ -76,10 +70,18 @@ body:
       and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false
+- type: input
+  attributes:
+    label: App or apps where you encountered the issue
+    description: Remember only [strictly confined snaps](https://snapcraft.io/docs/snap-confinement) are covered by App Permissions. Apps from the App Center are snaps. Debs, Flatpaks and AppImages are not.
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Additional context
     description: |
-      You can attach screenshots, recordings, logs (remember to anonymize!), or any other information that you think might be helpful.
+      You can attach screenshots, recordings, or any other information that you think might be helpful. You can also paste logs that seem relevant: you can get them running this command in your terminal: 
+      ```journalctl --user | grep prompting-client.daemon```
+      Please remember to anonymize any personal data.
   validations:
     required: false


### PR DESCRIPTION
- Add system info (including kernel version) + snap info field to GitHub issue template
- Add instructions on how to see logs for prompts

UDENG-4706