### PR TITLE
fix: update search for feature request link

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please search to see if an issue already exists for this feature: https://github.com/canonical/steam-snap/issues?q=label%3Aenhancement.
+      Please search to see if an issue already exists for this feature: https://github.com/canonical/desktop-security-center/issues?q=label%3Aenhancement.
     options:
     - label: I have searched the existing issues
       required: true


### PR DESCRIPTION
Noticed this while copying the issue templates over to other repos :slightly_smiling_face: 