### PR TITLE
fix: rename branch in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Flutter CI
 on:
   push:
     branches:
-      - security-center
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Looks like the CI isn't running on pushes to `main`, since the branch name is still set to `security-center` (probably from when it was part of the prompting repo).