### PR TITLE
ci: add osv scanner

### DIFF
--- a/.github/workflows/osv.yaml
+++ b/.github/workflows/osv.yaml
@@ -1,0 +1,31 @@
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  actions: read
+  security-events: write
+  contents: read
+
+jobs:
+  scan-push:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@f8115f2f28022984d4e8070d2f0f85abcf6f3458" # v1.9.2
+    with:
+      scan-args: |-
+        -r
+        ./
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@f8115f2f28022984d4e8070d2f0f85abcf6f3458" # v1.9.2
+    with:
+      scan-args: |-
+        -r
+        ./


### PR DESCRIPTION
This adds a workflow that runs [OSV-Scanner](https://google.github.io/osv-scanner/) on pull requests and pushes to `main` using https://github.com/google/osv-scanner-action. The [docs](https://google.github.io/osv-scanner/github-action/) seem to be somewhat outdated, so I adjusted the workflow as needed. On pull requests the `osv-scanner-reusable-pr.yml` workflow from the osv-scanner-action is triggered - it runs the scanner on both the `main` and PR branches and only fails if the PR introduced additional vulnerabilities. On merges to `main` the `osv-scanner-reusable.yml` workflow from the osv-scanner-action is run, which does a full scan of the repository.
As this action covers C/C++, Go, Dart and Rust, I'd propose using it as-is in our other repositories as well.

UDENG-6417