### PR TITLE
fix(a11y): Add copy semantic label

### DIFF
--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -211,7 +211,12 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                     decoration: InputDecoration(
                       labelText: l10n.diskEncryptionPageRecoveryKey,
                       suffixIcon: YaruIconButton(
-                        icon: const Icon(YaruIcons.copy, size: 16),
+                        icon: Icon(
+                          YaruIcons.copy,
+                          size: 16,
+                          semanticLabel:
+                              l10n.diskEncryptionPageCopySemanticLabel,
+                        ),
                         onPressed: () => saveToClipboard(
                           context,
                           recoveryKey.value!.recoveryKey,

--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -135,6 +135,8 @@
     "@diskEncryptionPageReplaceDialogQRBody": {},
     "diskEncryptionPageClipboardNotification": "Copied to clipboard",
     "@diskEncryptionPageClipboardNotification": {},
+    "diskEncryptionPageCopySemanticLabel": "Copy",
+    "@diskEncryptionPageCopySemanticLabel": {},
     "recoveryKeyExceptionFileSystemTitle": "Recovery key file not saved",
     "recoveryKeyExceptionDisallowedPathTitle": "Recovery key file cannot be saved in a temporary location",
     "recoveryKeyExceptionUnknownTitle": "Unknown error",

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -581,6 +581,12 @@ abstract class AppLocalizations {
   /// **'Copied to clipboard'**
   String get diskEncryptionPageClipboardNotification;
 
+  /// No description provided for @diskEncryptionPageCopySemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy'**
+  String get diskEncryptionPageCopySemanticLabel;
+
   /// No description provided for @recoveryKeyExceptionFileSystemTitle.
   ///
   /// In en, this message translates to:

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -200,6 +200,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -200,6 +200,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -200,6 +200,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -200,6 +200,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -200,6 +200,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -200,6 +200,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -200,6 +200,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -200,6 +200,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -200,6 +200,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -200,6 +200,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -200,6 +200,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -200,6 +200,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -200,6 +200,9 @@ class AppLocalizationsDz extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -200,6 +200,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -198,6 +198,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -200,6 +200,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -200,6 +200,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -200,6 +200,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -200,6 +200,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -200,6 +200,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -200,6 +200,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -200,6 +200,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -200,6 +200,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -200,6 +200,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -200,6 +200,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -200,6 +200,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -200,6 +200,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -200,6 +200,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -200,6 +200,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -200,6 +200,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -200,6 +200,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -200,6 +200,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -200,6 +200,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -200,6 +200,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -200,6 +200,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -200,6 +200,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -200,6 +200,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -200,6 +200,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -200,6 +200,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -200,6 +200,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -200,6 +200,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -200,6 +200,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -200,6 +200,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -200,6 +200,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -200,6 +200,9 @@ class AppLocalizationsNn extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -200,6 +200,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -200,6 +200,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -204,6 +204,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -200,6 +200,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -200,6 +200,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -202,6 +202,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSe extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -200,6 +200,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -200,6 +200,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -200,6 +200,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -200,6 +200,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -200,6 +200,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -200,6 +200,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -200,6 +200,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -200,6 +200,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -204,6 +204,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -200,6 +200,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -200,6 +200,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diskEncryptionPageClipboardNotification => 'Copied to clipboard';
 
   @override
+  String get diskEncryptionPageCopySemanticLabel => 'Copy';
+
+  @override
   String get recoveryKeyExceptionFileSystemTitle => 'Recovery key file not saved';
 
   @override


### PR DESCRIPTION
Adds a semantic label to the "click to copy" button in the disk encryption key text field.

**Note:** this change makes it so when the copy button is focused, the *entire text field is read again*, then the copy button semantics. This may or may not be desirable. It seems this behavior is the default behavior of Flutter text fields, and there doesn't seem to be a good solution that will result in only the copy button label to be read other than creating a custom text field.

Fixes https://github.com/canonical/desktop-security-center/issues/127

---

UDENG-7190