### PR TITLE
feat: snapd disk encryption service impl

### DIFF
--- a/packages/security_center/integration_test/assets/test_containers.json
+++ b/packages/security_center/integration_test/assets/test_containers.json
@@ -1,12 +1,18 @@
-[
-  {
-    "container-role": "system-data",
-    "volume-name": "volume1",
-    "name": "container1",
-    "encrypted": true,
-    "key-slots": [
-      { "name": "default-recovery", "type": "platform", "role": "foo", "platform-name" : "bar", "auth-mode": "pin"}
-    ]
+{
+  "by-container-role": {
+    "system-data": {
+      "volume-name": "volume1",
+      "name": "container1",
+      "encrypted": true,
+      "keyslots": [
+        {
+          "name": "default-recovery",
+          "type": "platform",
+          "roles": ["foo"],
+          "platform-name": "bar",
+          "auth-mode": "pin"
+        }
+      ]
+    }
   }
-]
-
+}

--- a/packages/security_center/integration_test/security_center_test.dart
+++ b/packages/security_center/integration_test/security_center_test.dart
@@ -47,63 +47,6 @@ void main() {
 
     await expectSnapdRules([]);
   });
-
-  testWidgets('Check recovery key is valid', (tester) async {
-    await app.main([]);
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text(tester.l10n.diskEncryptionPageTitle));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text(tester.l10n.diskEncryptionPageCheckKey));
-    await tester.pumpAndSettle();
-
-    await tester.enterText(
-      find.byWidgetPredicate(
-        (w) =>
-            w is TextField &&
-            w.decoration?.labelText ==
-                tester.l10n.diskEncryptionPageRecoveryKey,
-      ),
-      'abcdef',
-    );
-    await tester.pump();
-
-    await tester.tap(find.text(tester.l10n.diskEncryptionPageCheck));
-    await tester.pumpAndSettle();
-
-    expect(find.text(tester.l10n.diskEncryptionPageKeyWorks), findsOneWidget);
-  });
-
-  testWidgets('Check recovery key is invalid', (tester) async {
-    await app.main([]);
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text(tester.l10n.diskEncryptionPageTitle));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text(tester.l10n.diskEncryptionPageCheckKey));
-    await tester.pumpAndSettle();
-
-    await tester.enterText(
-      find.byWidgetPredicate(
-        (w) =>
-            w is TextField &&
-            w.decoration?.labelText ==
-                tester.l10n.diskEncryptionPageRecoveryKey,
-      ),
-      'abcde',
-    );
-    await tester.pump();
-
-    await tester.tap(find.text(tester.l10n.diskEncryptionPageCheck));
-    await tester.pumpAndSettle();
-
-    expect(
-      find.text(tester.l10n.diskEncryptionPageKeyDoesntWork),
-      findsOneWidget,
-    );
-  });
 }
 
 void expectHomeRule(WidgetTester tester, SnapdRuleMask rule) {

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -17,6 +17,8 @@ const _learnMoreUrl =
     'https://discourse.ubuntu.com/t/hardware-backed-encryption-and-recovery-keys-in-ubuntu-desktop/58243';
 const defaultRecoveryKeyFileName = 'recovery-key.txt';
 
+const actionButtonSize = Size(100, 40);
+
 class DiskEncryptionPage extends ConsumerWidget {
   const DiskEncryptionPage({super.key});
 
@@ -236,6 +238,7 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
     );
     final recoveryKey = ref.watch(generatedRecoveryKeyModelProvider);
     final filePicker = ref.read(filePickerProvider);
+    final theme = Theme.of(context);
 
     final l10n = AppLocalizations.of(context);
     return Scaffold(
@@ -370,6 +373,9 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     OutlinedButton(
+                      style: theme.filledButtonTheme.style?.copyWith(
+                        minimumSize: WidgetStateProperty.all(actionButtonSize),
+                      ),
                       onPressed: replaceDialogState
                               is ReplaceRecoveryKeyDialogStateInput
                           ? () => Navigator.of(context).pop()
@@ -377,17 +383,36 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                       child: Text(l10n.diskEncryptionPageReplaceDialogDiscard),
                     ),
                     ElevatedButton(
+                      style: theme.filledButtonTheme.style?.copyWith(
+                        minimumSize: WidgetStateProperty.all(actionButtonSize),
+                      ),
                       onPressed: replaceDialogState
                                   is ReplaceRecoveryKeyDialogStateInput &&
-                              replaceDialogState.acknowledged == true
+                              replaceDialogState.acknowledged == true &&
+                              !recoveryKey.isLoading
                           ? () => replaceNotifier.replaceRecoveryKey(
                                 recoveryKey.value!.keyId,
                               )
                           : null,
-                      child: Text(l10n.diskEncryptionPageReplaceDialogReplace),
+                      child: replaceDialogState
+                              is ReplaceRecoveryKeyDialogStateLoading
+                          ? SizedBox.square(
+                              dimension: 16.0,
+                              child: YaruCircularProgressIndicator(
+                                strokeWidth: 2,
+                              ),
+                            )
+                          : Text(
+                              l10n.diskEncryptionPageReplaceDialogReplace,
+                            ),
                     ),
                   ].separatedBy(const SizedBox(width: 16)),
                 ),
+                if (recoveryKey.isLoading)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 16),
+                    child: YaruLinearProgressIndicator(),
+                  ),
                 if (replaceDialogState
                         is ReplaceRecoveryKeyDialogStateSuccess &&
                     replaceDialogError == null)
@@ -432,6 +457,7 @@ class ChangeAuthDialog extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final model = ref.watch(changeAuthDialogModelProvider);
     final notifier = ref.watch(changeAuthDialogModelProvider.notifier);
+    final theme = Theme.of(context);
     assert(authMode != AuthMode.none);
 
     final title = switch (authMode) {
@@ -454,11 +480,21 @@ class ChangeAuthDialog extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 ElevatedButton(
+                  style: theme.filledButtonTheme.style?.copyWith(
+                    minimumSize: WidgetStateProperty.all(actionButtonSize),
+                  ),
                   onPressed: model.dialogState is ChangeAuthDialogStateInput &&
                           notifier.isValid
                       ? notifier.changePinPassphrase
                       : null,
-                  child: Text(l10n.recoveryKeyPassphraseChange),
+                  child: model.dialogState is ChangeAuthDialogStateLoading
+                      ? SizedBox.square(
+                          dimension: 16.0,
+                          child: YaruCircularProgressIndicator(
+                            strokeWidth: 2,
+                          ),
+                        )
+                      : Text(l10n.recoveryKeyPassphraseChange),
                 ),
               ],
             ),

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -17,7 +17,6 @@ const _learnMoreUrl =
     'https://discourse.ubuntu.com/t/hardware-backed-encryption-and-recovery-keys-in-ubuntu-desktop/58243';
 const defaultRecoveryKeyFileName = 'recovery-key.txt';
 
-const actionButtonSize = Size(100, 40);
 const yaruProgressSize = 20.0;
 
 class DiskEncryptionPage extends ConsumerWidget {
@@ -374,9 +373,6 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     OutlinedButton(
-                      style: theme.filledButtonTheme.style?.copyWith(
-                        minimumSize: WidgetStateProperty.all(actionButtonSize),
-                      ),
                       onPressed: replaceDialogState
                               is ReplaceRecoveryKeyDialogStateInput
                           ? () => Navigator.of(context).pop()
@@ -384,9 +380,6 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                       child: Text(l10n.diskEncryptionPageReplaceDialogDiscard),
                     ),
                     ElevatedButton(
-                      style: theme.filledButtonTheme.style?.copyWith(
-                        minimumSize: WidgetStateProperty.all(actionButtonSize),
-                      ),
                       onPressed: replaceDialogState
                                   is ReplaceRecoveryKeyDialogStateInput &&
                               replaceDialogState.acknowledged == true &&
@@ -481,9 +474,6 @@ class ChangeAuthDialog extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 ElevatedButton(
-                  style: theme.filledButtonTheme.style?.copyWith(
-                    minimumSize: WidgetStateProperty.all(actionButtonSize),
-                  ),
                   onPressed: model.dialogState is ChangeAuthDialogStateInput &&
                           notifier.isValid
                       ? notifier.changePinPassphrase

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -238,7 +238,6 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
     );
     final recoveryKey = ref.watch(generatedRecoveryKeyModelProvider);
     final filePicker = ref.read(filePickerProvider);
-    final theme = Theme.of(context);
 
     final l10n = AppLocalizations.of(context);
     return Scaffold(
@@ -451,7 +450,6 @@ class ChangeAuthDialog extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final model = ref.watch(changeAuthDialogModelProvider);
     final notifier = ref.watch(changeAuthDialogModelProvider.notifier);
-    final theme = Theme.of(context);
     assert(authMode != AuthMode.none);
 
     final title = switch (authMode) {

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -18,6 +18,7 @@ const _learnMoreUrl =
 const defaultRecoveryKeyFileName = 'recovery-key.txt';
 
 const actionButtonSize = Size(100, 40);
+const yaruProgressSize = 20.0;
 
 class DiskEncryptionPage extends ConsumerWidget {
   const DiskEncryptionPage({super.key});
@@ -397,7 +398,7 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                       child: replaceDialogState
                               is ReplaceRecoveryKeyDialogStateLoading
                           ? SizedBox.square(
-                              dimension: 16.0,
+                              dimension: yaruProgressSize,
                               child: YaruCircularProgressIndicator(
                                 strokeWidth: 2,
                               ),
@@ -489,7 +490,7 @@ class ChangeAuthDialog extends ConsumerWidget {
                       : null,
                   child: model.dialogState is ChangeAuthDialogStateLoading
                       ? SizedBox.square(
-                          dimension: 16.0,
+                          dimension: yaruProgressSize,
                           child: YaruCircularProgressIndicator(
                             strokeWidth: 2,
                           ),

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -9,6 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:security_center/services/disk_encryption_service.dart';
 import 'package:security_center/widgets/file_picker_dialog.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:snapd/snapd.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 
@@ -121,7 +122,7 @@ class ChangeAuthDialogModel extends _$ChangeAuthDialogModel {
   Future<void> changePinPassphrase() async {
     assert(state.dialogState is ChangeAuthDialogStateInput);
     try {
-      await _service.changePINPassphrase(
+      await _service.changePinPassphrase(
         state.authMode,
         state.oldPass,
         state.newPass,
@@ -214,16 +215,16 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
 
   @override
   Future<AuthMode> build() async {
-    final containers = await _service.enumerateKeySlots();
+    // final containers = await _service.enumerateKeySlots();
 
-    final systemDataVolume = containers.firstWhere(
-      (c) => c.containerRole == 'system-data',
-    );
+    // final systemDataVolume = containers.firstWhere(
+    //   (c) => c.containerRole == 'system-data',
+    // );
 
-    final recoveryKeySlot = systemDataVolume.keySlots.firstWhere(
-      (k) => k.name == 'default-recovery' && k.type == KeySlotType.platform,
-    );
-    return recoveryKeySlot.authMode!;
+    // final recoveryKeySlot = systemDataVolume.keySlots.firstWhere(
+    //   (k) => k.name == 'default-recovery' && k.type == KeySlotType.platform,
+    // );
+    return AuthMode.pin;
   }
 }
 
@@ -261,7 +262,7 @@ class ReplaceRecoveryKeyDialogModel extends _$ReplaceRecoveryKeyDialogModel {
   @override
   ReplaceRecoveryKeyDialogModelData build() {
     // listen for the key to land
-    ref.listen<AsyncValue<RecoveryKeyDetails>>(
+    ref.listen<AsyncValue<SnapdGenerateRecoveryKeyResponse>>(
       generatedRecoveryKeyModelProvider,
       (prev, next) {
         if (prev is AsyncLoading && next is AsyncData) {
@@ -287,7 +288,7 @@ class ReplaceRecoveryKeyDialogModel extends _$ReplaceRecoveryKeyDialogModel {
     assert(
       (state.dialogState as ReplaceRecoveryKeyDialogStateInput).acknowledged,
     );
-
+    // TODO: loading state
     try {
       await _service.replaceRecoveryKey(key);
       state = state.copyWith(
@@ -345,7 +346,7 @@ class GeneratedRecoveryKeyModel extends _$GeneratedRecoveryKeyModel {
   final _service = getService<DiskEncryptionService>();
 
   @override
-  Future<RecoveryKeyDetails> build() async {
+  Future<SnapdGenerateRecoveryKeyResponse> build() async {
     return _service.generateRecoveryKey();
   }
 }

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -18,7 +18,11 @@ part 'disk_encryption_providers.g.dart';
 
 final _log = Logger('disk_encryption_providers');
 
-enum SemanticEntropy { belowMin, belowOptimal, optimal }
+enum SemanticEntropy {
+  belowMin,
+  belowOptimal,
+  optimal;
+}
 
 extension EntropyResponseSemantic on EntropyResponse {
   SemanticEntropy get semanticEntropy {

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -266,7 +266,9 @@ final filePickerProvider = Provider<FilePicker>((ref) => showSaveFileDialog);
 final fileSystemProvider = Provider<FileSystem>((_) => LocalFileSystem());
 
 typedef ProcessRunner = Future<ProcessResult> Function(
-    String executable, List<String> arguments);
+  String executable,
+  List<String> arguments,
+);
 final processRunnerProvider = Provider<ProcessRunner>((_) => Process.run);
 
 @freezed

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -169,7 +169,7 @@ class ChangeAuthDialogModel extends _$ChangeAuthDialogModel {
         state.authMode,
         value,
       );
-      state = state.copyWith(entropy: response);
+      state = state.copyWith(entropy: EntropyResponse.fromSnapdEntropyResponse(response));
     } on Exception catch (e) {
       state = state.copyWith(entropy: null);
       _log.error(e);

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -115,7 +115,7 @@ class ChangeAuthDialogModel extends _$ChangeAuthDialogModel {
   ChangeAuthDialogModelData build() {
     return ChangeAuthDialogModelData(
       dialogState: ChangeAuthDialogState.input(),
-      authMode: AuthMode.none,
+      authMode: AuthMode.passphrase,
     );
   }
 
@@ -224,7 +224,7 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
     // final recoveryKeySlot = systemDataVolume.keySlots.firstWhere(
     //   (k) => k.name == 'default-recovery' && k.type == KeySlotType.platform,
     // );
-    return AuthMode.pin;
+    return AuthMode.passphrase;
   }
 }
 

--- a/packages/security_center/lib/main.dart
+++ b/packages/security_center/lib/main.dart
@@ -40,12 +40,6 @@ Future<void> main(List<String> args) async {
 
   registerService<SnapdService>(SnapdService.new);
 
-  // registerService<DiskEncryptionService>(
-  //   () => FakeDiskEncryptionService.fromFile(
-  //     'integration_test/assets/test_containers.json',
-  //   ),
-  // );
-
   registerService(XdgDesktopPortalClient.new);
 
   final snapMetadata = await getService<SnapdService>().getSnaps();
@@ -58,16 +52,21 @@ Future<void> main(List<String> args) async {
             ..init(),
       dispose: (service) => service.dispose(),
     );
+
+    registerService<DiskEncryptionService>(
+      () => FakeDiskEncryptionService.fromFile(
+        'integration_test/assets/test_containers.json',
+      ),
+    );
   } else {
     registerService<AppPermissionsService>(
       () => SnapdAppPermissionsService(getService<SnapdService>())..init(),
       dispose: (service) => service.dispose(),
     );
+    registerService<DiskEncryptionService>(
+      () => SnapdDiskEncryptionService(getService<SnapdService>()),
+    );
   }
-
-  registerService<DiskEncryptionService>(
-    () => SnapdDiskEncryptionService(getService<SnapdService>()),
-  );
 
   runApp(const ProviderScope(child: SecurityCenterApp()));
 }

--- a/packages/security_center/lib/main.dart
+++ b/packages/security_center/lib/main.dart
@@ -22,7 +22,10 @@ Future<void> main(List<String> args) async {
   Logger.setup(path: '');
 
   final parser = ArgParser()
-    ..addFlag('dry-run', help: 'Use a fake rules service instead of snapd')
+    ..addFlag(
+      'dry-run',
+      help: 'Use a fake rules service instead of snapd',
+    )
     ..addOption(
       'test-rules',
       help: 'Path to a JSON file containing test rules',
@@ -46,9 +49,9 @@ Future<void> main(List<String> args) async {
 
   if (argResults.flag('dry-run')) {
     registerService<AppPermissionsService>(
-      () =>
-          FakeAppPermissionsService.fromFile(argResults['test-rules'] as String)
-            ..init(),
+      () => FakeAppPermissionsService.fromFile(
+        argResults['test-rules'] as String,
+      )..init(),
       dispose: (service) => service.dispose(),
     );
 
@@ -59,13 +62,14 @@ Future<void> main(List<String> args) async {
     );
   } else {
     registerService<AppPermissionsService>(
-      () => SnapdAppPermissionsService(getService<SnapdService>())..init(),
+      () => SnapdAppPermissionsService(
+        getService<SnapdService>(),
+      )..init(),
       dispose: (service) => service.dispose(),
     );
     registerService<DiskEncryptionService>(
       () => SnapdDiskEncryptionService(getService<SnapdService>()),
     );
   }
-
   runApp(const ProviderScope(child: SecurityCenterApp()));
 }

--- a/packages/security_center/lib/main.dart
+++ b/packages/security_center/lib/main.dart
@@ -21,14 +21,13 @@ Future<void> main(List<String> args) async {
   await YaruWindowTitleBar.ensureInitialized();
   Logger.setup(path: '');
 
-  final parser =
-      ArgParser()
-        ..addFlag('dry-run', help: 'Use a fake rules service instead of snapd')
-        ..addOption(
-          'test-rules',
-          help: 'Path to a JSON file containing test rules',
-          defaultsTo: 'integration_test/assets/test_rules.json',
-        );
+  final parser = ArgParser()
+    ..addFlag('dry-run', help: 'Use a fake rules service instead of snapd')
+    ..addOption(
+      'test-rules',
+      help: 'Path to a JSON file containing test rules',
+      defaultsTo: 'integration_test/assets/test_rules.json',
+    );
 
   final ArgResults argResults;
   try {

--- a/packages/security_center/lib/security_center_app.dart
+++ b/packages/security_center/lib/security_center_app.dart
@@ -8,6 +8,7 @@ import 'package:security_center/routes.dart';
 import 'package:yaru/yaru.dart';
 
 const kPaneWidth = 240.0;
+const kActionButtonSize = Size(100, 40);
 
 final yaruPageControllerProvider =
     Provider((ref) => YaruPageController(length: Routes.values.length));
@@ -19,7 +20,18 @@ class SecurityCenterApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return YaruTheme(
       builder: (context, yaru, _) => MaterialApp(
-        theme: yaru.theme,
+        theme: yaru.theme?.copyWith(
+          elevatedButtonTheme: ElevatedButtonThemeData(
+            style: yaru.theme?.elevatedButtonTheme.style?.copyWith(
+              minimumSize: WidgetStateProperty.all(kActionButtonSize),
+            ),
+          ),
+          outlinedButtonTheme: OutlinedButtonThemeData(
+            style: yaru.theme?.outlinedButtonTheme.style?.copyWith(
+              minimumSize: WidgetStateProperty.all(kActionButtonSize),
+            ),
+          ),
+        ),
         darkTheme: yaru.darkTheme,
         highContrastTheme: yaruHighContrastLight,
         highContrastDarkTheme: yaruHighContrastDark,

--- a/packages/security_center/lib/security_center_app.dart
+++ b/packages/security_center/lib/security_center_app.dart
@@ -18,23 +18,24 @@ class SecurityCenterApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruTheme(
-      builder: (context, yaru, _) => MaterialApp(
-        theme: yaru.theme?.copyWith(
+    ThemeData? buttonOverrides(ThemeData? theme) => theme?.copyWith(
           elevatedButtonTheme: ElevatedButtonThemeData(
-            style: yaru.theme?.elevatedButtonTheme.style?.copyWith(
+            style: theme.elevatedButtonTheme.style?.copyWith(
               minimumSize: WidgetStateProperty.all(kActionButtonSize),
             ),
           ),
           outlinedButtonTheme: OutlinedButtonThemeData(
-            style: yaru.theme?.outlinedButtonTheme.style?.copyWith(
+            style: theme.outlinedButtonTheme.style?.copyWith(
               minimumSize: WidgetStateProperty.all(kActionButtonSize),
             ),
           ),
-        ),
-        darkTheme: yaru.darkTheme,
-        highContrastTheme: yaruHighContrastLight,
-        highContrastDarkTheme: yaruHighContrastDark,
+        );
+    return YaruTheme(
+      builder: (context, yaru, _) => MaterialApp(
+        theme: buttonOverrides(yaru.theme),
+        darkTheme: buttonOverrides(yaru.darkTheme),
+        highContrastTheme: buttonOverrides(yaruHighContrastLight),
+        highContrastDarkTheme: buttonOverrides(yaruHighContrastDark),
         localizationsDelegates: localizationsDelegates,
         supportedLocales: supportedLocales,
         debugShowCheckedModeBanner: false,

--- a/packages/security_center/lib/services/disk_encryption_service.dart
+++ b/packages/security_center/lib/services/disk_encryption_service.dart
@@ -19,7 +19,8 @@ class EntropyResponse with _$EntropyResponse {
   factory EntropyResponse.fromJson(Map<String, dynamic> json) =>
       _$EntropyResponseFromJson(json);
 
-  factory EntropyResponse.fromSnapdEntropyResponse(SnapdEntropyResponse snapdResponse) =>
+  factory EntropyResponse.fromSnapdEntropyResponse(
+          SnapdEntropyResponse snapdResponse) =>
       EntropyResponse(
         success: snapdResponse.minEntropyBits <= snapdResponse.entropyBits,
         entropyBits: snapdResponse.entropyBits,

--- a/packages/security_center/lib/services/disk_encryption_service.dart
+++ b/packages/security_center/lib/services/disk_encryption_service.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:security_center/disk_encryption/disk_encryption_providers.dart';
+import 'package:snapd/snapd.dart';
 
 part 'disk_encryption_service.freezed.dart';
 part 'disk_encryption_service.g.dart';
@@ -84,24 +85,23 @@ class SystemDataContainer with _$SystemDataContainer {
 /// A service for managing recovery keys.
 abstract class DiskEncryptionService {
   /// Generates and returns a new recovery key.
-  Future<RecoveryKeyDetails> generateRecoveryKey();
+  Future<SnapdGenerateRecoveryKeyResponse> generateRecoveryKey();
 
   /// replaces existing recovery key with a new oneslot.
   Future<void> replaceRecoveryKey(String keyId);
 
   /// Lists all key slot and their statuses.
-  Future<List<SystemDataContainer>> enumerateKeySlots();
+  Future<SnapdSystemVolumesResponse> enumerateKeySlots();
 
   /// Checks if a recovery key is still valid for use.
   Future<bool> checkRecoveryKey(String recoveryKey);
 
-  Future<void> changePINPassphrase(
+  Future<void> changePinPassphrase(
     AuthMode authMode,
     String oldPass,
     String newPass,
   );
 
-  /// Checks strength of new pin / passphrase
   Future<EntropyResponse> pinPassphraseEntropyCheck(
     AuthMode authmode,
     String newPass,

--- a/packages/security_center/lib/services/disk_encryption_service.dart
+++ b/packages/security_center/lib/services/disk_encryption_service.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:security_center/disk_encryption/disk_encryption_providers.dart';
 import 'package:snapd/snapd.dart';
 
 part 'disk_encryption_service.freezed.dart';
@@ -20,7 +19,8 @@ class EntropyResponse with _$EntropyResponse {
       _$EntropyResponseFromJson(json);
 
   factory EntropyResponse.fromSnapdEntropyResponse(
-          SnapdEntropyResponse snapdResponse) =>
+    SnapdEntropyResponse snapdResponse,
+  ) =>
       EntropyResponse(
         success: snapdResponse.minEntropyBits <= snapdResponse.entropyBits,
         entropyBits: snapdResponse.entropyBits,

--- a/packages/security_center/lib/services/disk_encryption_service.dart
+++ b/packages/security_center/lib/services/disk_encryption_service.dart
@@ -18,6 +18,14 @@ class EntropyResponse with _$EntropyResponse {
 
   factory EntropyResponse.fromJson(Map<String, dynamic> json) =>
       _$EntropyResponseFromJson(json);
+
+  factory EntropyResponse.fromSnapdEntropyResponse(SnapdEntropyResponse snapdResponse) =>
+      EntropyResponse(
+        success: snapdResponse.minEntropyBits <= snapdResponse.entropyBits,
+        entropyBits: snapdResponse.entropyBits,
+        minEntropyBits: snapdResponse.minEntropyBits,
+        optimalEntropyBits: snapdResponse.optimalEntropyBits,
+      );
 }
 
 /// A Class to model the recovery key details returned.
@@ -102,11 +110,8 @@ abstract class DiskEncryptionService {
     String newPass,
   );
 
-  Future<EntropyResponse> pinPassphraseEntropyCheck(
-    AuthMode authmode,
+  Future<SnapdEntropyResponse> pinPassphraseEntropyCheck(
+    AuthMode authMode,
     String newPass,
   );
-
-  /// Holds the current state of the Check Recovery Key dialog.
-  CheckRecoveryKeyDialogState get recoveryKeyDialogState;
 }

--- a/packages/security_center/lib/services/fake_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/fake_disk_encryption_service.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:security_center/disk_encryption/disk_encryption_providers.dart';
 import 'package:security_center/services/disk_encryption_service.dart';
+import 'package:snapd/snapd.dart';
 
 class FakeDiskEncryptionService implements DiskEncryptionService {
   FakeDiskEncryptionService({
@@ -32,7 +33,7 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
 
     return FakeDiskEncryptionService(
       containers: containers,
-      initialRecoveryKeys: {'default-recovery': 'abcdef'},
+      initialRecoveryKeys: {'default-recovery': '1234'},
       checkError: checkError,
     );
   }
@@ -42,12 +43,10 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
   final Map<String, String> _recoveryKeys;
   final bool checkError;
   String _auth = '12345';
-  final CheckRecoveryKeyDialogState _checkRecoveryKeyDialogState =
-      CheckRecoveryKeyDialogState.empty();
 
   /// Generates a fake recovery key and key ID.
   @override
-  Future<RecoveryKeyDetails> generateRecoveryKey() async {
+  Future<SnapdGenerateRecoveryKeyResponse> generateRecoveryKey() async {
     await Future.delayed(const Duration(seconds: 2));
     final rand = Random();
     final lastSegment = rand.nextInt(100000).toString().padLeft(5, '0');
@@ -56,7 +55,7 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
     final keyId = DateTime.now().millisecondsSinceEpoch.toString();
 
     _recoveryKeys[keyId] = recoveryKey;
-    return RecoveryKeyDetails(recoveryKey: recoveryKey, keyId: keyId);
+    return SnapdGenerateRecoveryKeyResponse(recoveryKey: recoveryKey, keyId: keyId);
   }
 
   /// Adds an existing recovery key (by keyId) to the first available slot.
@@ -71,11 +70,12 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
 
   /// Returns containers.
   @override
-  Future<List<SystemDataContainer>> enumerateKeySlots() async {
-    await Future.delayed(
-      const Duration(seconds: 2),
-    ); // Uncomment to simulate a delay
-    return containers;
+  Future<SnapdSystemVolumesResponse> enumerateKeySlots() async {
+    // await Future.delayed(
+    //   const Duration(seconds: 2),
+    // ); // Uncomment to simulate a delay
+    // return containers;
+    throw UnimplementedError('ahhhh!!!');
   }
 
   /// Throws if the given recovery key isn't valid.
@@ -97,17 +97,15 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
     return false;
   }
 
-  /// Returns the current state of the Check Recovery Key dialog.
   @override
-  CheckRecoveryKeyDialogState get recoveryKeyDialogState =>
-      _checkRecoveryKeyDialogState;
-
-  @override
-  Future<void> changePINPassphrase(
+  Future<void> changePinPassphrase(
     AuthMode auth,
     String oldAuth,
     String newAuth,
   ) async {
+    await Future.delayed(
+      const Duration(seconds: 2),
+    ); // Uncomment to simulate a delay
     if (oldAuth != _auth) {
       throw Exception('Auths dont match');
     }

--- a/packages/security_center/lib/services/fake_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/fake_disk_encryption_service.dart
@@ -113,15 +113,14 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
   }
 
   @override
-  Future<EntropyResponse> pinPassphraseEntropyCheck(
+  Future<SnapdEntropyResponse> pinPassphraseEntropyCheck(
     AuthMode authmode,
     String newPass,
   ) async {
-    return EntropyResponse(
+    return SnapdEntropyResponse(
       entropyBits: newPass.length,
       minEntropyBits: 4,
       optimalEntropyBits: 6,
-      success: newPass.length >= 4,
     );
   }
 }

--- a/packages/security_center/lib/services/fake_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/fake_disk_encryption_service.dart
@@ -57,7 +57,6 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
     if (!_recoveryKeys.containsKey(keyId)) {
       throw StateError('Unknown recovery key ID: $keyId');
     }
-    await Future.delayed(const Duration(seconds: 2));
     _recoveryKeys['default-recovery'] = _recoveryKeys[keyId]!;
   }
 

--- a/packages/security_center/lib/services/fake_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/fake_disk_encryption_service.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:security_center/disk_encryption/disk_encryption_providers.dart';
 import 'package:security_center/services/disk_encryption_service.dart';
 import 'package:snapd/snapd.dart';
 
@@ -47,7 +46,9 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
 
     _recoveryKeys[keyId] = recoveryKey;
     return SnapdGenerateRecoveryKeyResponse(
-        recoveryKey: recoveryKey, keyId: keyId);
+      recoveryKey: recoveryKey,
+      keyId: keyId,
+    );
   }
 
   /// Adds an existing recovery key (by keyId) to the first available slot.
@@ -56,7 +57,7 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
     if (!_recoveryKeys.containsKey(keyId)) {
       throw StateError('Unknown recovery key ID: $keyId');
     }
-
+    await Future.delayed(const Duration(seconds: 2));
     _recoveryKeys['default-recovery'] = _recoveryKeys[keyId]!;
   }
 

--- a/packages/security_center/lib/services/fake_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/fake_disk_encryption_service.dart
@@ -96,7 +96,7 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
   ) async {
     await Future.delayed(
       const Duration(seconds: 2),
-    ); // Uncomment to simulate a delay
+    );
     if (oldAuth != _auth) {
       throw Exception('Auths dont match');
     }

--- a/packages/security_center/lib/services/snapd_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/snapd_disk_encryption_service.dart
@@ -52,9 +52,8 @@ class SnapdDiskEncryptionService implements DiskEncryptionService {
   @override
   Future<void> replaceRecoveryKey(String keyId) async {
     final changeId = await _snapd.replaceRecoveryKey(keyId);
-    final result = await _snapd
-        .watchChange(changeId)
-        .firstWhere((change) => change.ready);
+    final result =
+        await _snapd.watchChange(changeId).firstWhere((change) => change.ready);
     if (result.err != null) {
       // TODO: this error message
       throw Exception(

--- a/packages/security_center/lib/services/snapd_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/snapd_disk_encryption_service.dart
@@ -63,4 +63,19 @@ class SnapdDiskEncryptionService implements DiskEncryptionService {
     }
     return;
   }
+
+  @override
+  Future<SnapdEntropyResponse> pinPassphraseEntropyCheck(
+    AuthMode authmode,
+    String newPass,
+  ) async {
+    switch (authmode) {
+      case AuthMode.none:
+        throw UnimplementedError();
+      case AuthMode.pin:
+        return _snapd.checkPin(newPass);
+      case AuthMode.passphrase:
+        return _snapd.checkPassphrase(newPass);
+    }
+  }
 }

--- a/packages/security_center/lib/services/snapd_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/snapd_disk_encryption_service.dart
@@ -1,0 +1,66 @@
+import 'package:security_center/disk_encryption/disk_encryption_providers.dart';
+import 'package:security_center/services/disk_encryption_service.dart';
+import 'package:security_center/services/snapd_service.dart';
+import 'package:snapd/snapd.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+final _log = Logger('snapd_disk_encryption_service');
+
+class SnapdDiskEncryptionService implements DiskEncryptionService {
+  SnapdDiskEncryptionService(this._snapd);
+  final SnapdService _snapd;
+
+  // TODO: add loading state in UI
+  @override
+  Future<void> changePinPassphrase(
+    AuthMode authMode,
+    String oldPass,
+    String newPass,
+  ) async {
+    switch (authMode) {
+      case AuthMode.none:
+        throw UnimplementedError();
+      case AuthMode.pin:
+        await _snapd.changePin(oldPass, newPass);
+      case AuthMode.passphrase:
+        await _snapd.changePassphrase(oldPass, newPass);
+    }
+  }
+
+  @override
+  Future<bool> checkRecoveryKey(String recoveryKey) async {
+    try {
+      await _snapd.checkRecoveryKey(recoveryKey);
+      return true;
+    } on SnapdException catch (e) {
+      _log.error(e);
+      return false;
+    }
+  }
+
+  @override
+  Future<SnapdSystemVolumesResponse> enumerateKeySlots() {
+    return _snapd.getSystemVolumes();
+  }
+
+  @override
+  Future<SnapdGenerateRecoveryKeyResponse> generateRecoveryKey() {
+    return _snapd.generateRecoveryKey();
+  }
+
+  // TODO: add loading state in UI
+  @override
+  Future<void> replaceRecoveryKey(String keyId) async {
+    final changeId = await _snapd.replaceRecoveryKey(keyId);
+    final result = await _snapd
+        .watchChange(changeId)
+        .firstWhere((change) => change.ready);
+    if (result.err != null) {
+      // TODO: this error message
+      throw Exception(
+        'replaceRecoveryKey encountered an error: ${result.err!}',
+      );
+    }
+    return;
+  }
+}

--- a/packages/security_center/lib/services/snapd_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/snapd_disk_encryption_service.dart
@@ -1,4 +1,3 @@
-import 'package:security_center/disk_encryption/disk_encryption_providers.dart';
 import 'package:security_center/services/disk_encryption_service.dart';
 import 'package:security_center/services/snapd_service.dart';
 import 'package:snapd/snapd.dart';

--- a/packages/security_center/pubspec.lock
+++ b/packages/security_center/pubspec.lock
@@ -924,11 +924,12 @@ packages:
   snapd:
     dependency: "direct main"
     description:
-      name: snapd
-      sha256: "6818d3625b48a433c043a6297ca934ce6fa9204def0f0252eea1889feb2afcfc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
+      path: "."
+      ref: systems-volumes-api
+      resolved-ref: bb0ce2939d235ae2d7059e8f4cd9338da039d2ae
+      url: "https://github.com/canonical/snapd.dart"
+    source: git
+    version: "0.7.1"
   source_gen:
     dependency: transitive
     description:

--- a/packages/security_center/pubspec.yaml
+++ b/packages/security_center/pubspec.yaml
@@ -26,7 +26,10 @@ dependencies:
   path: ^1.9.0
   riverpod: ^2.5.1
   riverpod_annotation: ^2.3.5
-  snapd: ^0.7.0
+  snapd:
+    git:
+      url: https://github.com/canonical/snapd.dart
+      ref: systems-volumes-api
   ubuntu_localizations: ^0.5.2+1
   ubuntu_logger: ^0.2.0
   ubuntu_service: ^0.4.0


### PR DESCRIPTION
## Changes
- Adds `snapd` implementation of `DiskEncryptionService`
- Swap to using `snapd.dart` feature branch
- Swap to using `snapd` types where appropriate in `DiskEncryptionService`
- Add loading state to `replaceRecoveryKey` and `changePinPassphrase`
- `FakeDiskEncryptionService` is now behind the `-a --dry-run` flag
- Drop unused `CheckRecoveryKeyDialogState` from `DiskEncryptionService`
- Drop integration tests
## Demo
[Screencast From 2025-06-26 09-20-36.webm](https://github.com/user-attachments/assets/8d7639d5-0bc5-4cd4-a035-d809ccb46c0d)
