### PR TITLE
feat: debounce text field input when changing pin/pass

### DIFF
--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -449,7 +449,7 @@ class ChangeAuthDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final model = ref.watch(changeAuthDialogModelProvider);
-    final notifier = ref.watch(changeAuthDialogModelProvider.notifier);
+    final notifier = ref.read(changeAuthDialogModelProvider.notifier);
     assert(authMode != AuthMode.none);
 
     final title = switch (authMode) {

--- a/packages/security_center/lib/widgets/passphrase_widgets.dart
+++ b/packages/security_center/lib/widgets/passphrase_widgets.dart
@@ -120,31 +120,39 @@ class _PassphraseFormFieldState extends ConsumerState<PassphraseFormField> {
     return Row(
       children: [
         Expanded(
-          child: TextFormField(
-            controller: _controller,
-            decoration: InputDecoration(
-              labelText: widget.authMode.localizedNewHint(lang),
-              errorText: model.entropy != null && !model.entropy!.success
-                  ? model.entropy?.semanticEntropy.localizedHint(
-                      l10n,
-                      widget.authMode,
-                    )
-                  : null,
-              helperText: model.entropy?.semanticEntropy ==
-                          SemanticEntropy.belowOptimal ||
-                      model.entropy?.semanticEntropy == SemanticEntropy.optimal
-                  ? model.entropy?.semanticEntropy.localizedHint(
-                      l10n,
-                      widget.authMode,
-                    )
-                  : null,
-              helperStyle: Theme.of(context).textTheme.bodySmall,
-              helperMaxLines: 2,
-              errorMaxLines: 2,
+          child: Focus(
+            onFocusChange: (hasFocus) {
+              if (!hasFocus) {
+                notifier.setNewPass(_controller.text);
+              }
+            },
+            child: TextFormField(
+              controller: _controller,
+              decoration: InputDecoration(
+                labelText: widget.authMode.localizedNewHint(lang),
+                errorText: model.entropy != null && !model.entropy!.success
+                    ? model.entropy?.semanticEntropy.localizedHint(
+                        l10n,
+                        widget.authMode,
+                      )
+                    : null,
+                helperText: model.entropy?.semanticEntropy ==
+                            SemanticEntropy.belowOptimal ||
+                        model.entropy?.semanticEntropy ==
+                            SemanticEntropy.optimal
+                    ? model.entropy?.semanticEntropy.localizedHint(
+                        l10n,
+                        widget.authMode,
+                      )
+                    : null,
+                helperStyle: Theme.of(context).textTheme.bodySmall,
+                helperMaxLines: 2,
+                errorMaxLines: 2,
+              ),
+              obscureText: !model.showPassphrase,
+              enabled: !isDisabled,
+              onChanged: (value) => notifier.setNewPass(value, debounce: true),
             ),
-            obscureText: !model.showPassphrase,
-            enabled: !isDisabled,
-            onChanged: notifier.setNewPass,
           ),
         ),
         if (model.entropy != null &&
@@ -204,19 +212,26 @@ class _ConfirmPassphraseFormFieldState
     return Row(
       children: [
         Expanded(
-          child: TextFormField(
-            controller: _controller,
-            decoration: InputDecoration(
-              labelText: widget.authMode.localizedConfirmHint(lang),
-              errorText: !notifier.passphraseConfirmed
-                  ? widget.authMode.localizedConfirmError(lang)
-                  : null,
-            ),
-            obscureText: !model.showPassphrase,
-            enabled: !isDisabled,
-            onChanged: (value) {
-              notifier.confirmPass = value;
+          child: Focus(
+            onFocusChange: (hasFocus) {
+              if (!hasFocus) {
+                notifier.setConfirmPass(_controller.text);
+              }
             },
+            child: TextFormField(
+              controller: _controller,
+              decoration: InputDecoration(
+                labelText: widget.authMode.localizedConfirmHint(lang),
+                errorText: !notifier.passphraseConfirmed
+                    ? widget.authMode.localizedConfirmError(lang)
+                    : null,
+              ),
+              obscureText: !model.showPassphrase,
+              enabled: !isDisabled,
+              onChanged: (value) {
+                notifier.setConfirmPass(value, debounce: true);
+              },
+            ),
           ),
         ),
         if (model.confirmPass.isNotEmpty &&

--- a/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
+++ b/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
@@ -10,6 +10,8 @@ import 'package:yaru/yaru.dart';
 import '../test_utils.dart';
 
 void main() {
+  const debounceDelay = Duration(milliseconds: 500);
+
   testWidgets('recovery key is valid', (tester) async {
     final container = createContainer();
     registerMockDiskEncryptionService();
@@ -586,7 +588,7 @@ void main() {
           await tester.enterText(textFields.at(1), 'newpass');
           await tester.enterText(textFields.at(2), 'different');
         }
-        await tester.pump();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Button should still be disabled due to validation error
         expect(tester.widget<ElevatedButton>(changeButton).enabled, isFalse);
@@ -648,7 +650,7 @@ void main() {
           await tester.enterText(textFields.at(1), 'new');
           await tester.enterText(textFields.at(2), 'new');
         }
-        await tester.pump();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Button should still be disabled due to validation error
         expect(tester.widget<ElevatedButton>(changeButton).enabled, isFalse);
@@ -667,7 +669,7 @@ void main() {
           await tester.enterText(textFields.at(1), 'newp');
           await tester.enterText(textFields.at(2), 'newp');
         }
-        await tester.pump();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Button should be active
         expect(tester.widget<ElevatedButton>(changeButton).enabled, isTrue);
@@ -686,7 +688,7 @@ void main() {
           await tester.enterText(textFields.at(1), 'newpas');
           await tester.enterText(textFields.at(2), 'newpas');
         }
-        await tester.pump();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Button should still be active
         expect(tester.widget<ElevatedButton>(changeButton).enabled, isTrue);
@@ -769,14 +771,14 @@ void main() {
           await tester.enterText(textFields.at(1), 'newpass');
           await tester.enterText(textFields.at(2), 'newpass');
         }
-        await tester.pump();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Button should now be enabled with valid inputs
         expect(tester.widget<ElevatedButton>(changeButton).enabled, isTrue);
 
         // Submit the form
         await tester.tap(changeButton);
-        await tester.pumpAndSettle();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Check the result based on success/failure
         if (tc.changePinPassphraseError) {
@@ -846,7 +848,7 @@ void main() {
         await tester.enterText(textFields.at(0), mixedInput);
         await tester.enterText(textFields.at(1), mixedInput);
         await tester.enterText(textFields.at(2), mixedInput);
-        await tester.pump();
+        await tester.pumpAndSettle(debounceDelay);
 
         // Check the actual text in the controllers based on auth mode
         final expectedText = tc.authMode == AuthMode.pin ? '1234' : mixedInput;


### PR DESCRIPTION
This PR adds a 500ms delay before sending request to calculate the entropy of a pin/pass while the user is editing the text field. If the user un-focuses the field, the request is sent immediately.

[Screencast From 2025-07-01 10-08-03.webm](https://github.com/user-attachments/assets/ac89a8d0-bfa3-4eb9-b41a-f9ded5cbf33c)

@matthew-hagemann there are no changes compared to what we did yesterday. I don't think there's too much value in adding any test cases that check the UI state before the debounce duration has passed, so I just added `pumpAndSettle(debounceDuration)` where needed.

Fix #133 

UDENG-7286