### PR TITLE
feat: add snap-fde-control interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ apps:
     plugs:
       - network
       - snapd-control
+      - snap-fde-control
 
 parts:
   fvm:


### PR DESCRIPTION
Adds the `snapd-fde-control` interface to access the `/v2/system-volumes` endpoint of the new snapd API for TPM FDE.