### PR TITLE
fix: follow rename of Settings › Applications to Apps

### DIFF
--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -26,7 +26,7 @@
     "@snapPermissionsDisablingLabel": {},
     "snapPermissionsExperimentalLabel": "Experimental",
     "@snapPermissionsExperimentalLabel": {},
-    "snapPermissionsOtherDescription": "You can manage other permissions in Settings › Applications.",
+    "snapPermissionsOtherDescription": "You can manage other permissions in Settings › Apps.",
     "@snapPermissionsOtherDescription": {},
     "snapPermissionsPageTitle": "App Permissions",
     "@snapPermissionsPageTitle": {},

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -320,7 +320,7 @@ abstract class AppLocalizations {
   /// No description provided for @snapPermissionsOtherDescription.
   ///
   /// In en, this message translates to:
-  /// **'You can manage other permissions in Settings › Applications.'**
+  /// **'You can manage other permissions in Settings › Apps.'**
   String get snapPermissionsOtherDescription;
 
   /// No description provided for @snapPermissionsPageTitle.

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -48,7 +48,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get snapPermissionsExperimentalLabel => 'Experimental';
 
   @override
-  String get snapPermissionsOtherDescription => 'You can manage other permissions in Settings › Applications.';
+  String get snapPermissionsOtherDescription => 'You can manage other permissions in Settings › Apps.';
 
   @override
   String get snapPermissionsPageTitle => 'App Permissions';


### PR DESCRIPTION
The gnome-control-center panel is named `Apps` (although it previously was named `Applications`).

I updated the English translations but I didn't touch the other translations.