### PR TITLE
feat: log errors from failed snapd changes

### DIFF
--- a/packages/security_center/lib/services/snapd_app_permissions_service.dart
+++ b/packages/security_center/lib/services/snapd_app_permissions_service.dart
@@ -166,6 +166,9 @@ class SnapdAppPermissionsService implements AppPermissionsService {
         if (change.ready) {
           break;
         } else if (change.err != null) {
+          _log.error(
+            'Snapd change $changeId completed with an error: ${change.err}',
+          );
           _emitStatus(AppPermissionsServiceStatus.error(change.err!));
           break;
         }


### PR DESCRIPTION
Adds a log statement to make it easier to debug issues with activating/deactivating the permission prompting feature.

UDENG-8459