### PR TITLE
feat: upgrade snap to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: desktop-security-center
-base: core22
+base: core24
 version: git
 summary: Desktop Security Center
 description: Security Center UI for the desktop


### PR DESCRIPTION
The security center snap was originally built on core24 but had to be reverted to core22 in #79. This PR updates it to core24 again.

UDENG-8516