### PR TITLE
fix: drop state mutations for authMode in changeAuthDialog's

### DIFF
--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -472,8 +472,8 @@ class ChangeAuthDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final model = ref.watch(changeAuthDialogModelProvider);
-    final notifier = ref.read(changeAuthDialogModelProvider.notifier);
+    final model = ref.watch(changeAuthDialogModelProvider(authMode));
+    final notifier = ref.read(changeAuthDialogModelProvider(authMode).notifier);
     assert(authMode != AuthMode.none);
 
     final title = switch (authMode) {
@@ -779,11 +779,6 @@ class _PassphraseAuthenticationActions extends ConsumerWidget {
               onPressed: isRemoving
                   ? null
                   : () {
-                      ref
-                          .read(
-                            changeAuthDialogModelProvider.notifier,
-                          )
-                          .authMode = AuthMode.passphrase;
                       showChangeAuthDialog(
                         context,
                         AuthMode.passphrase,
@@ -846,11 +841,6 @@ class _PinAuthenticationActions extends ConsumerWidget {
               onPressed: isRemoving
                   ? null
                   : () {
-                      ref
-                          .read(
-                            changeAuthDialogModelProvider.notifier,
-                          )
-                          .authMode = AuthMode.pin;
                       showChangeAuthDialog(context, AuthMode.pin);
                     },
               child: Text(l10n.recoveryKeyPinButton),

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -187,14 +187,14 @@ class ChangeAuthDialogModel extends _$ChangeAuthDialogModel {
   static const debounceDuration = Duration(milliseconds: 500);
 
   @override
-  ChangeAuthDialogModelData build() {
+  ChangeAuthDialogModelData build(AuthMode authMode) {
     ref.onDispose(() {
       _newPassTimer?.cancel();
       _confirmTimer?.cancel();
     });
     return ChangeAuthDialogModelData(
       dialogState: ChangeAuthDialogState.input(),
-      authMode: AuthMode.passphrase,
+      authMode: authMode,
     );
   }
 
@@ -221,13 +221,6 @@ class ChangeAuthDialogModel extends _$ChangeAuthDialogModel {
   void toggleShowPassphrase() {
     if (state.dialogState is! ChangeAuthDialogStateInput) return;
     state = state.copyWith(showPassphrase: !state.showPassphrase);
-  }
-
-  set authMode(AuthMode authmode) {
-    state = state.copyWith(
-      authMode: authmode,
-      dialogState: ChangeAuthDialogStateInput(),
-    );
   }
 
   Future<void> setConfirmPass(

--- a/packages/security_center/lib/widgets/passphrase_widgets.dart
+++ b/packages/security_center/lib/widgets/passphrase_widgets.dart
@@ -31,7 +31,7 @@ class _CurrentPassphraseFormFieldState
 
   @override
   void initState() {
-    final model = ref.read(changeAuthDialogModelProvider);
+    final model = ref.read(changeAuthDialogModelProvider(widget.authMode));
     assert(widget.authMode != AuthMode.none);
 
     super.initState();
@@ -43,8 +43,9 @@ class _CurrentPassphraseFormFieldState
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(changeAuthDialogModelProvider);
-    final notifier = ref.watch(changeAuthDialogModelProvider.notifier);
+    final model = ref.watch(changeAuthDialogModelProvider(widget.authMode));
+    final notifier =
+        ref.watch(changeAuthDialogModelProvider(widget.authMode).notifier);
     final lang = AppLocalizations.of(context);
     final isDisabled = model.dialogState is ChangeAuthDialogStateSuccess ||
         (model.dialogState is ChangeAuthDialogStateError &&
@@ -57,7 +58,7 @@ class _CurrentPassphraseFormFieldState
             controller: _controller,
             decoration: InputDecoration(
               labelText: widget.authMode.localizedCurrentHint(lang),
-              suffixIcon: const _SecurityKeyShowButton(),
+              suffixIcon: _SecurityKeyShowButton(authMode: widget.authMode),
             ),
             obscureText: !model.showPassphrase,
             enabled: !isDisabled,
@@ -100,7 +101,7 @@ class _PassphraseFormFieldState extends ConsumerState<PassphraseFormField> {
 
   @override
   void initState() {
-    final model = ref.read(changeAuthDialogModelProvider);
+    final model = ref.read(changeAuthDialogModelProvider(widget.authMode));
     assert(widget.authMode != AuthMode.none);
 
     super.initState();
@@ -112,8 +113,9 @@ class _PassphraseFormFieldState extends ConsumerState<PassphraseFormField> {
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(changeAuthDialogModelProvider);
-    final notifier = ref.watch(changeAuthDialogModelProvider.notifier);
+    final model = ref.watch(changeAuthDialogModelProvider(widget.authMode));
+    final notifier =
+        ref.watch(changeAuthDialogModelProvider(widget.authMode).notifier);
     final lang = AppLocalizations.of(context);
     final isDisabled = model.dialogState is ChangeAuthDialogStateSuccess ||
         (model.dialogState is ChangeAuthDialogStateError &&
@@ -198,7 +200,7 @@ class _ConfirmPassphraseFormFieldState
 
   @override
   void initState() {
-    final model = ref.read(changeAuthDialogModelProvider);
+    final model = ref.read(changeAuthDialogModelProvider(widget.authMode));
     assert(widget.authMode != AuthMode.none);
 
     super.initState();
@@ -210,8 +212,9 @@ class _ConfirmPassphraseFormFieldState
 
   @override
   Widget build(BuildContext context) {
-    final model = ref.watch(changeAuthDialogModelProvider);
-    final notifier = ref.watch(changeAuthDialogModelProvider.notifier);
+    final model = ref.watch(changeAuthDialogModelProvider(widget.authMode));
+    final notifier =
+        ref.watch(changeAuthDialogModelProvider(widget.authMode).notifier);
     final lang = AppLocalizations.of(context);
     final isDisabled = model.dialogState is ChangeAuthDialogStateSuccess ||
         (model.dialogState is ChangeAuthDialogStateError &&
@@ -273,14 +276,16 @@ void _filterDigits(TextEditingController controller) {
 }
 
 class _SecurityKeyShowButton extends ConsumerWidget {
-  const _SecurityKeyShowButton();
+  const _SecurityKeyShowButton({required this.authMode});
+
+  final AuthMode authMode;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final lang = AppLocalizations.of(context);
-    final model = ref.watch(changeAuthDialogModelProvider);
-    final notifier = ref.read(changeAuthDialogModelProvider.notifier);
+    final model = ref.watch(changeAuthDialogModelProvider(authMode));
+    final notifier = ref.read(changeAuthDialogModelProvider(authMode).notifier);
     final showSecurityKey = model.showPassphrase;
     final isDisabled = model.dialogState is ChangeAuthDialogStateSuccess ||
         (model.dialogState is ChangeAuthDialogStateError &&


### PR DESCRIPTION
I dropped the setters from the `changeAuthDialog` and moved to using different provider families for each `authMode`. Run this through in a vm and all seems working as intended now.