### PR TITLE
fix: flickering camera toggle 

### DIFF
--- a/packages/security_center/lib/app_permissions/snaps_page.dart
+++ b/packages/security_center/lib/app_permissions/snaps_page.dart
@@ -231,6 +231,7 @@ class _CameraInterfaceAppTile extends ConsumerWidget {
         _log.error('Failed to load camera rules for snap $snapName: $error');
         return (false, null);
       },
+      skipLoadingOnReload: true,
     );
 
     return SecurityCenterListTile(


### PR DESCRIPTION
This fixes the flickering toggle for camera permissions.

Before:
[Screencast da 2026-02-05 12-52-44.webm](https://github.com/user-attachments/assets/76239f74-4ba2-428b-a9f3-608e3d80fcd7)


After:
[Screencast da 2026-02-05 13-03-54.webm](https://github.com/user-attachments/assets/815b7426-8d6b-428f-b7d2-4d33dad96946)

