### PR TITLE
fix: Increase snapd requirement for Pro support

### DIFF
--- a/packages/security_center/lib/services/feature_service.dart
+++ b/packages/security_center/lib/services/feature_service.dart
@@ -50,7 +50,7 @@ class FeatureService {
   bool get supportsProControl {
     if (isDryRun) return true;
 
-    return _hasGreaterSnapdVersion(snapdVersion, '2.74.1');
+    return _hasGreaterSnapdVersion(snapdVersion, '2.75.1');
   }
 
   bool _hasStorageEncryptedManaged() {

--- a/packages/security_center/test/services/feature_service_test.dart
+++ b/packages/security_center/test/services/feature_service_test.dart
@@ -96,22 +96,22 @@ factory: true
   group('Snapd version', () {
     for (final testCase in [
       (
-        name: 'snapd version < 2.74.1, no microphone or pro interfaces',
-        snapdVersion: '2.74',
+        name: 'snapd version < 2.75, no microphone or pro interfaces',
+        snapdVersion: '2.74.1',
         isDryRun: false,
         wantMicrophone: false,
         wantPro: false,
       ),
       (
-        name: 'snapd version == 2.74.1, no microphone support, pro supported',
-        snapdVersion: '2.74.1',
+        name: 'snapd version == 2.75, microphone support, no pro supported',
+        snapdVersion: '2.75',
         isDryRun: false,
-        wantMicrophone: false,
-        wantPro: true,
+        wantMicrophone: true,
+        wantPro: false,
       ),
       (
-        name: 'snapd version == 2.75, microphone and pro interface supported',
-        snapdVersion: '2.75',
+        name: 'snapd version == 2.75.1, microphone and pro interface supported',
+        snapdVersion: '2.75.1',
         isDryRun: false,
         wantMicrophone: true,
         wantPro: true,
@@ -126,7 +126,7 @@ factory: true
       (
         name:
             'snapd version with v prefix, microphone and pro interface supported',
-        snapdVersion: 'v2.75',
+        snapdVersion: 'v2.75.1',
         isDryRun: false,
         wantMicrophone: true,
         wantPro: true,
@@ -141,7 +141,7 @@ factory: true
       ),
       (
         name: 'snapd version with dev hash suffix',
-        snapdVersion: '2.75+g137.7313916',
+        snapdVersion: '2.75.1+g137.7313916',
         isDryRun: false,
         wantMicrophone: true,
         wantPro: true,
@@ -151,14 +151,14 @@ factory: true
         snapdVersion: '2.74.1',
         isDryRun: false,
         wantMicrophone: false,
-        wantPro: true,
+        wantPro: false,
       ),
       (
         name: 'snapd version 2.75.0',
         snapdVersion: '2.75.0',
         isDryRun: false,
         wantMicrophone: true,
-        wantPro: true,
+        wantPro: false,
       ),
       (
         name: 'snapd version 2.75.1',


### PR DESCRIPTION
Increases the snapd requirement to 2.75.1 for Pro support. 2.75.1 should contain *all* the necessary pieces for proper support, so it is a better cutoff point.