### PR TITLE
fix: use correct interface for microphones

### DIFF
--- a/packages/security_center/lib/app_permissions/rules_providers.dart
+++ b/packages/security_center/lib/app_permissions/rules_providers.dart
@@ -39,13 +39,13 @@ Future<List<SnapdRule>> rules(Ref ref) async =>
 @riverpod
 Future<List<String>> cameraSnaps(Ref ref) async {
   final service = getService<AppPermissionsService>();
-  return service.getSnapsWithInterface('camera');
+  return service.getSnapsWithInterface(SnapdInterface.camera.interfaceName);
 }
 
 @riverpod
 Future<List<String>> microphoneSnaps(Ref ref) async {
   final service = getService<AppPermissionsService>();
-  return service.getSnapsWithInterface('microphone');
+  return service.getSnapsWithInterface(SnapdInterface.microphone.interfaceName);
 }
 
 @riverpod
@@ -84,18 +84,18 @@ Future<Map<String, int>> snapRuleCounts(
   return switch (interface) {
     SnapdInterface.camera => _buildSnapCountsMap(
         rules,
-        interface.name,
+        interface.interfaceName,
         await ref.watch(cameraSnapsProvider.future),
       ),
     SnapdInterface.microphone => _buildSnapCountsMap(
         rules,
-        interface.name,
+        interface.interfaceName,
         await ref.watch(microphoneSnapsProvider.future),
       ),
     _ => rules.fold<Map<String, int>>(
         {},
         (counts, rule) {
-          if (rule.interface == interface.name) {
+          if (rule.interface == interface.interfaceName) {
             counts[rule.snap] = (counts[rule.snap] ?? 0) + 1;
           }
           return counts;
@@ -130,7 +130,10 @@ class SnapRulesModel extends _$SnapRulesModel {
   }) async {
     final rules = await ref.watch(rulesProvider.future);
     return rules
-        .where((rule) => rule.snap == snap && rule.interface == interface.name)
+        .where(
+          (rule) =>
+              rule.snap == snap && rule.interface == interface.interfaceName,
+        )
         .toList();
   }
 
@@ -144,7 +147,7 @@ class SnapRulesModel extends _$SnapRulesModel {
     final service = getService<AppPermissionsService>();
     await service.removeAllRules(
       snap: snap,
-      interface: interface.name,
+      interface: interface.interfaceName,
     );
     ref.invalidate(rulesProvider);
   }
@@ -189,7 +192,7 @@ class SnapHomeRulesModel extends _$SnapHomeRulesModel {
     final service = getService<AppPermissionsService>();
     await service.removeAllRules(
       snap: snap,
-      interface: SnapdInterface.home.name,
+      interface: SnapdInterface.home.interfaceName,
     );
     ref.invalidate(rulesProvider);
   }
@@ -235,7 +238,7 @@ class SnapCameraRulesModel extends _$SnapCameraRulesModel {
 
     final rule = SnapdRuleMask(
       snap: snap,
-      interface: SnapdInterface.camera.name,
+      interface: SnapdInterface.camera.interfaceName,
       constraints: constraints.toJson(),
     );
 
@@ -248,7 +251,7 @@ class SnapCameraRulesModel extends _$SnapCameraRulesModel {
     final service = getService<AppPermissionsService>();
     await service.removeAllRules(
       snap: snap,
-      interface: SnapdInterface.camera.name,
+      interface: SnapdInterface.camera.interfaceName,
     );
     ref.invalidate(rulesProvider);
   }
@@ -294,7 +297,7 @@ class SnapMicrophoneRulesModel extends _$SnapMicrophoneRulesModel {
 
     final rule = SnapdRuleMask(
       snap: snap,
-      interface: SnapdInterface.microphone.name,
+      interface: SnapdInterface.microphone.interfaceName,
       constraints: constraints.toJson(),
     );
 
@@ -307,7 +310,7 @@ class SnapMicrophoneRulesModel extends _$SnapMicrophoneRulesModel {
     final service = getService<AppPermissionsService>();
     await service.removeAllRules(
       snap: snap,
-      interface: SnapdInterface.microphone.name,
+      interface: SnapdInterface.microphone.interfaceName,
     );
     ref.invalidate(rulesProvider);
   }

--- a/packages/security_center/lib/app_permissions/snapd_interface.dart
+++ b/packages/security_center/lib/app_permissions/snapd_interface.dart
@@ -15,7 +15,7 @@ enum SnapdInterface {
   static SnapdInterface fromString(String? name) => switch (name) {
         'home' => home,
         'camera' => camera,
-        'microphone' => microphone,
+        'audio-record' => microphone,
         _ => throw ArgumentError('Unknown interface: $name'),
       };
 
@@ -34,6 +34,12 @@ enum SnapdInterface {
         home => YaruIcons.folder,
         camera => YaruIcons.camera_photo,
         microphone => YaruIcons.microphone
+      };
+
+  String get interfaceName => switch (this) {
+        home => 'home',
+        camera => 'camera',
+        microphone => 'audio-record',
       };
 }
 

--- a/packages/security_center/lib/services/fake_app_permissions_service.dart
+++ b/packages/security_center/lib/services/fake_app_permissions_service.dart
@@ -103,10 +103,10 @@ class FakeAppPermissionsService implements AppPermissionsService {
 
   @override
   Future<List<String>> getSnapsWithInterface(String interface) async {
-    if (interface == 'camera') {
+    if (interface == SnapdInterface.camera.interfaceName) {
       return ['firefox', 'thunderbird', 'cheese'];
     }
-    if (interface == 'microphone') {
+    if (interface == SnapdInterface.microphone.interfaceName) {
       return ['firefox', 'obs-studio'];
     }
     return [];

--- a/packages/security_center/test/app_permissions/snaps_page_test.dart
+++ b/packages/security_center/test/app_permissions/snaps_page_test.dart
@@ -371,7 +371,7 @@ void main() {
             id: 'microphoneRule1',
             timestamp: DateTime(2024),
             snap: 'firefox',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -385,7 +385,7 @@ void main() {
             id: 'microphoneRule2',
             timestamp: DateTime(2024),
             snap: 'cheese',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -453,14 +453,14 @@ void main() {
             id: 'microphoneRule1',
             timestamp: DateTime(2024),
             snap: 'firefox',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {},
           ),
           SnapdRule(
             id: 'microphoneRule2',
             timestamp: DateTime(2024),
             snap: 'cheese',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -504,13 +504,17 @@ void main() {
       await tester.tap(firefoxSwitch);
       await tester.pumpAndSettle();
 
-      verify(service.removeAllRules(snap: 'firefox', interface: 'microphone'))
-          .called(1);
+      verify(
+        service.removeAllRules(
+          snap: 'firefox',
+          interface: SnapdInterface.microphone.interfaceName,
+        ),
+      ).called(1);
       verify(
         service.addRule(
           SnapdRuleMask(
             snap: 'firefox',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -538,13 +542,17 @@ void main() {
       await tester.tap(cheeseSwitch);
       await tester.pumpAndSettle();
 
-      verify(service.removeAllRules(snap: 'cheese', interface: 'microphone'))
-          .called(1);
+      verify(
+        service.removeAllRules(
+          snap: 'cheese',
+          interface: SnapdInterface.microphone.interfaceName,
+        ),
+      ).called(1);
       verify(
         service.addRule(
           SnapdRuleMask(
             snap: 'cheese',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -568,7 +576,7 @@ void main() {
             id: 'microphoneRule1',
             timestamp: DateTime(2024),
             snap: 'firefox',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -582,7 +590,7 @@ void main() {
             id: 'microphoneRule2',
             timestamp: DateTime(2024),
             snap: 'cheese',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -596,7 +604,7 @@ void main() {
             id: 'microphoneRule3',
             timestamp: DateTime(2024),
             snap: 'obs-studio',
-            interface: 'microphone',
+            interface: SnapdInterface.microphone.interfaceName,
             constraints: {
               'permissions': {
                 'access': {
@@ -629,12 +637,23 @@ void main() {
       await tester.tap(resetButton);
       await tester.pumpAndSettle();
 
-      verify(service.removeAllRules(snap: 'firefox', interface: 'microphone'))
-          .called(1);
-      verify(service.removeAllRules(snap: 'cheese', interface: 'microphone'))
-          .called(1);
       verify(
-        service.removeAllRules(snap: 'obs-studio', interface: 'microphone'),
+        service.removeAllRules(
+          snap: 'firefox',
+          interface: SnapdInterface.microphone.interfaceName,
+        ),
+      ).called(1);
+      verify(
+        service.removeAllRules(
+          snap: 'cheese',
+          interface: SnapdInterface.microphone.interfaceName,
+        ),
+      ).called(1);
+      verify(
+        service.removeAllRules(
+          snap: 'obs-studio',
+          interface: SnapdInterface.microphone.interfaceName,
+        ),
       ).called(1);
     });
   });


### PR DESCRIPTION
The interface name has a hyphen, which is why we need to add a getter