### PR TITLE
fix: multiple UX fixes

### DIFF
--- a/packages/security_center/lib/app_permissions/app_rules_page.dart
+++ b/packages/security_center/lib/app_permissions/app_rules_page.dart
@@ -3,10 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:security_center/app_permissions/home_interface.dart';
 import 'package:security_center/app_permissions/rules_category.dart';
 import 'package:security_center/app_permissions/rules_providers.dart';
-import 'package:security_center/app_permissions/snap_metadata_providers.dart';
 import 'package:security_center/app_permissions/snapd_interface.dart';
 import 'package:security_center/l10n.dart';
-import 'package:security_center/widgets/app_icon.dart';
 import 'package:security_center/widgets/empty_rules_tile.dart';
 import 'package:security_center/widgets/scrollable_page.dart';
 import 'package:yaru/yaru.dart';
@@ -49,28 +47,9 @@ class _HomeBody extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final notifier = ref.read(snapHomeRulesModelProvider(snap: snap).notifier);
     final l10n = AppLocalizations.of(context);
-    final textTheme = Theme.of(context).textTheme;
 
     return ScrollablePage(
       children: [
-        Row(
-          children: [
-            AppIcon(snapIcon: ref.watch(snapIconProvider(snap))),
-            const SizedBox(width: 10),
-            Text(
-              ref.watch(snapTitleOrNameProvider(snap)),
-              style: textTheme.titleLarge,
-            ),
-          ],
-        ),
-        const SizedBox(height: 10),
-        Text(
-          l10n.snapRulesPageDescription(
-            SnapdInterface.home.localizedTitle(l10n),
-            snap,
-          ),
-        ),
-        const SizedBox(height: 32),
         if (ruleFragments.isEmpty) ...[
           const YaruTileList(
             children: [

--- a/packages/security_center/lib/app_permissions/interfaces_page.dart
+++ b/packages/security_center/lib/app_permissions/interfaces_page.dart
@@ -177,7 +177,7 @@ class _InterfaceList extends ConsumerWidget {
                               ? l10n.cameraRulesPageEmptyTileLabel
                               : l10n.snapRulesPageEmptyTileLabel),
                     ),
-                    trailing: const Icon(YaruIcons.pan_end),
+                    trailing: const Icon(YaruIcons.go_next),
                     onTap: () => Navigator.of(context).pushSnapPermissions(
                       interface: interfaceSnapCount.key,
                     ),

--- a/packages/security_center/lib/app_permissions/snapd_interface.dart
+++ b/packages/security_center/lib/app_permissions/snapd_interface.dart
@@ -24,12 +24,6 @@ enum SnapdInterface {
         camera => l10n.cameraInterfacePageTitle,
         microphone => l10n.microphoneInterfacePageTitle,
       };
-  String localizedDescription(AppLocalizations l10n) => switch (this) {
-        home => l10n.homeInterfacePageDescription,
-        camera => l10n.cameraInterfacePageDescription,
-        microphone => l10n.microphoneInterfacePageDescription,
-      };
-
   IconData get icon => switch (this) {
         home => YaruIcons.folder,
         camera => YaruIcons.camera_photo,

--- a/packages/security_center/lib/app_permissions/snaps_page.dart
+++ b/packages/security_center/lib/app_permissions/snaps_page.dart
@@ -279,7 +279,7 @@ class _CameraInterfaceAppTile extends ConsumerWidget {
       ),
       titleText: ref.watch(snapTitleOrNameProvider(snapName)),
       subtitle: subtitle != null ? Text(subtitle) : null,
-      trailing: Switch(
+      trailing: YaruSwitch(
         value: isOn,
         onChanged: (value) async {
           await notifier.removeAll();
@@ -360,7 +360,7 @@ class _MicrophoneInterfaceAppTile extends ConsumerWidget {
       ),
       titleText: ref.watch(snapTitleOrNameProvider(snapName)),
       subtitle: subtitle != null ? Text(subtitle) : null,
-      trailing: Switch(
+      trailing: YaruSwitch(
         value: isOn,
         onChanged: (value) async {
           await notifier.removeAll();

--- a/packages/security_center/lib/app_permissions/snaps_page.dart
+++ b/packages/security_center/lib/app_permissions/snaps_page.dart
@@ -68,7 +68,6 @@ class _HomeInterfaceBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context);
     final tiles = snapRuleCounts.entries
         .map(
           (e) => _HomeInterfaceAppTile(
@@ -83,8 +82,6 @@ class _HomeInterfaceBody extends ConsumerWidget {
         .toList();
     return ScrollablePage(
       children: [
-        Text(interface.localizedDescription(l10n)),
-        const SizedBox(height: 24),
         YaruTileList(
           children:
               tiles.isEmpty ? [EmptyRulesTile(interface: interface)] : tiles,
@@ -116,8 +113,6 @@ class _CameraInterfaceBody extends ConsumerWidget {
 
     return ScrollablePage(
       children: [
-        Text(interface.localizedDescription(l10n)),
-        const SizedBox(height: 24),
         YaruTileList(
           children: appTiles.isEmpty
               ? [EmptyRulesTile(interface: interface)]
@@ -167,8 +162,6 @@ class _MicrophoneInterfaceBody extends ConsumerWidget {
 
     return ScrollablePage(
       children: [
-        Text(interface.localizedDescription(l10n)),
-        const SizedBox(height: 24),
         YaruTileList(
           children: appTiles.isEmpty
               ? [EmptyRulesTile(interface: interface)]

--- a/packages/security_center/lib/app_permissions/snaps_page.dart
+++ b/packages/security_center/lib/app_permissions/snaps_page.dart
@@ -116,11 +116,6 @@ class _CameraInterfaceBody extends ConsumerWidget {
 
     return ScrollablePage(
       children: [
-        Text(
-          interface.localizedTitle(l10n),
-          style: Theme.of(context).textTheme.titleLarge,
-        ),
-        const SizedBox(height: 12),
         Text(interface.localizedDescription(l10n)),
         const SizedBox(height: 24),
         YaruTileList(
@@ -172,11 +167,6 @@ class _MicrophoneInterfaceBody extends ConsumerWidget {
 
     return ScrollablePage(
       children: [
-        Text(
-          interface.localizedTitle(l10n),
-          style: Theme.of(context).textTheme.titleLarge,
-        ),
-        const SizedBox(height: 12),
         Text(interface.localizedDescription(l10n)),
         const SizedBox(height: 24),
         YaruTileList(

--- a/packages/security_center/lib/app_permissions/snaps_page.dart
+++ b/packages/security_center/lib/app_permissions/snaps_page.dart
@@ -209,7 +209,7 @@ class _HomeInterfaceAppTile extends ConsumerWidget {
       ),
       titleText: ref.watch(snapTitleOrNameProvider(snapName)),
       subtitle: Text(l10n.snapRulesCount(ruleCount)),
-      trailing: const Icon(YaruIcons.pan_end),
+      trailing: const Icon(YaruIcons.go_next),
       onTap: onTap,
     );
   }

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -143,36 +143,9 @@ class CheckRecoveryKeyDialog extends ConsumerWidget {
           children: [
             TextField(
               autofocus: true,
-              style: TextStyle(
-                inherit: false,
-                fontFamily: 'Ubuntu Mono',
-                fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
-                textBaseline: TextBaseline.alphabetic,
-                color: Theme.of(context).colorScheme.onSurface,
-                height: 1.5,
-                letterSpacing: 0,
-              ),
               decoration: InputDecoration(
                 labelText: l10n.diskEncryptionPageRecoveryKey,
                 hintText: 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX',
-                labelStyle: TextStyle(
-                  inherit: false,
-                  fontFamily: 'Ubuntu Mono',
-                  fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
-                  textBaseline: TextBaseline.alphabetic,
-                  color: Theme.of(context).colorScheme.onSurface,
-                  height: 1.5,
-                  letterSpacing: 0,
-                ),
-                hintStyle: TextStyle(
-                  inherit: false,
-                  fontFamily: 'Ubuntu Mono',
-                  fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
-                  textBaseline: TextBaseline.alphabetic,
-                  color: Theme.of(context).colorScheme.onSurface,
-                  height: 1.5,
-                  letterSpacing: 0,
-                ),
               ),
               onChanged: notifier.setKeyToCheck,
             ),
@@ -303,15 +276,6 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                     readOnly: true,
                     minLines: 1,
                     maxLines: 2,
-                    style: TextStyle(
-                      inherit: false,
-                      fontFamily: 'Ubuntu Mono',
-                      fontSize:
-                          Theme.of(context).textTheme.bodyMedium!.fontSize,
-                      textBaseline: TextBaseline.alphabetic,
-                      color: Theme.of(context).colorScheme.onSurface,
-                      letterSpacing: 0,
-                    ),
                   ),
                 Row(
                   children: [
@@ -660,17 +624,7 @@ class _RecoveryKeyQRDialog extends ConsumerWidget {
               width: 200,
               height: 200,
             ),
-            Text(
-              recoveryKey,
-              style: TextStyle(
-                inherit: false,
-                fontFamily: 'Ubuntu Mono',
-                fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
-                textBaseline: TextBaseline.alphabetic,
-                color: Theme.of(context).colorScheme.onSurface,
-                letterSpacing: 0,
-              ),
-            ),
+            Text(recoveryKey),
           ],
         ),
       ),

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -143,6 +143,7 @@ class CheckRecoveryKeyDialog extends ConsumerWidget {
           children: [
             TextField(
               autofocus: true,
+              style: Theme.of(context).textTheme.bodyMedium,
               decoration: InputDecoration(
                 labelText: l10n.diskEncryptionPageRecoveryKey,
                 hintText: 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX',
@@ -248,6 +249,7 @@ class ReplaceRecoveryKeyDialog extends ConsumerWidget {
                   YaruLinearProgressIndicator()
                 else if (recoveryKey is AsyncData)
                   TextFormField(
+                    style: Theme.of(context).textTheme.bodyMedium,
                     onTap: () => saveToClipboard(
                       context,
                       recoveryKey.value!.recoveryKey,

--- a/packages/security_center/lib/navigator.dart
+++ b/packages/security_center/lib/navigator.dart
@@ -47,7 +47,7 @@ extension AppNavigatorState on NavigatorState {
     final route = Uri(
       path: Routes.appPermissions.route,
       queryParameters: {
-        if (interface != null) 'interface': interface.name,
+        if (interface != null) 'interface': interface.interfaceName,
         if (snap != null) 'snap': snap,
       },
     ).toString();

--- a/packages/security_center/test/app_permissions/app_rules_page_test.dart
+++ b/packages/security_center/test/app_permissions/app_rules_page_test.dart
@@ -93,8 +93,6 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('firefox'), findsOneWidget);
-
     await tester.tap(
       find.descendant(
         of: find.byWidgetPredicate(
@@ -114,7 +112,6 @@ void main() {
         },
       ),
     ).called(1);
-    expect(find.text('firefox'), findsOneWidget);
 
     final removeAll = find.text(tester.l10n.snapRulesRemoveAll);
     await tester.ensureVisible(removeAll);
@@ -138,7 +135,6 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('firefox'), findsOneWidget);
     expect(find.text(tester.l10n.snapRulesPageEmptyTileLabel), findsOneWidget);
   });
 }
@@ -160,8 +156,6 @@ Future<void> displayAndDeleteRulesTest({
     ),
   );
   await tester.pump();
-
-  expect(find.text('firefox'), findsOneWidget);
 
   await tester.tap(
     find.descendant(

--- a/packages/security_center/test/app_permissions/snaps_page_test.dart
+++ b/packages/security_center/test/app_permissions/snaps_page_test.dart
@@ -129,15 +129,6 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(
-        find.text(SnapdInterface.camera.localizedTitle(tester.l10n)),
-        findsOneWidget,
-      );
-      expect(
-        find.text(SnapdInterface.camera.localizedDescription(tester.l10n)),
-        findsOneWidget,
-      );
-
       expect(find.text('firefox'), findsOneWidget);
       expect(find.text('cheese'), findsOneWidget);
       expect(find.text('obs-studio'), findsOneWidget);
@@ -408,15 +399,6 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-
-      expect(
-        find.text(tester.l10n.microphoneInterfacePageTitle),
-        findsOneWidget,
-      );
-      expect(
-        find.text(tester.l10n.microphoneInterfacePageDescription),
-        findsOneWidget,
-      );
 
       final firefoxTile = find.ancestor(
         of: find.text('firefox'),

--- a/packages/security_center/test/app_permissions/snaps_page_test.dart
+++ b/packages/security_center/test/app_permissions/snaps_page_test.dart
@@ -199,7 +199,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final switchWidgets = find.byType(Switch);
+      final switchWidgets = find.byType(YaruSwitch);
       expect(switchWidgets, findsNWidgets(2));
 
       // Find firefox's switch
@@ -209,10 +209,10 @@ void main() {
       );
       final firefoxSwitch = find.descendant(
         of: firefoxTile,
-        matching: find.byType(Switch),
+        matching: find.byType(YaruSwitch),
       );
 
-      final firefoxSwitchValue = tester.widget<Switch>(firefoxSwitch).value;
+      final firefoxSwitchValue = tester.widget<YaruSwitch>(firefoxSwitch).value;
       expect(firefoxSwitchValue, false);
 
       // Toggle firefox on
@@ -246,7 +246,7 @@ void main() {
       );
       final cheeseSwitch = find.descendant(
         of: cheeseTile,
-        matching: find.byType(Switch),
+        matching: find.byType(YaruSwitch),
       );
 
       // Toggle cheese off
@@ -466,7 +466,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final switchWidgets = find.byType(Switch);
+      final switchWidgets = find.byType(YaruSwitch);
       expect(switchWidgets, findsNWidgets(2));
 
       // Find firefox's switch
@@ -476,10 +476,10 @@ void main() {
       );
       final firefoxSwitch = find.descendant(
         of: firefoxTile,
-        matching: find.byType(Switch),
+        matching: find.byType(YaruSwitch),
       );
 
-      final firefoxSwitchValue = tester.widget<Switch>(firefoxSwitch).value;
+      final firefoxSwitchValue = tester.widget<YaruSwitch>(firefoxSwitch).value;
       expect(firefoxSwitchValue, false);
 
       // Toggle firefox on
@@ -517,7 +517,7 @@ void main() {
       );
       final cheeseSwitch = find.descendant(
         of: cheeseTile,
-        matching: find.byType(Switch),
+        matching: find.byType(YaruSwitch),
       );
 
       // Toggle cheese off


### PR DESCRIPTION
# Remove redundant header texts and descriptions from permission pages
<img width="847" height="643" alt="image" src="https://github.com/user-attachments/assets/4e56e107-a71e-43f5-96d9-fb541db07d9a" />

# Use YaruSwitch instead of Switch in snaps page

<img width="847" height="643" alt="image" src="https://github.com/user-attachments/assets/dc5193c1-20ba-48b9-bfc3-0dab4f8722cf" />

# Use YaruIcons.go_next for navigable list tile chevrons

<img width="847" height="643" alt="image" src="https://github.com/user-attachments/assets/95588c9b-5db2-4706-8c32-0462e17b4212" />

# Remove monospace font from recovery key input and display

<img width="834" height="636" alt="Screenshot From 2026-04-09 22-57-30" src="https://github.com/user-attachments/assets/c5523f01-34a6-4fd6-a5b9-144910d3f187" />
<img width="834" height="636" alt="Screenshot From 2026-04-09 22-57-35" src="https://github.com/user-attachments/assets/48714397-a975-4bca-91bd-88e636f88b94" />
<img width="834" height="636" alt="Screenshot From 2026-04-09 22-57-53" src="https://github.com/user-attachments/assets/971fd816-4b3e-4d81-bba6-4c224dfcba79" />
