### PR TITLE
feat: Show an error if Ubuntu Pro detach fails

### DIFF
--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -290,6 +290,7 @@
     "ubuntuProDisablePro": "Disable Ubuntu Pro",
     "ubuntuProDisable": "Disable",
     "ubuntuProDisablePrompt": "Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?",
+    "ubuntuProDisableError": "Could not disable Ubuntu Pro. Please try again.",
     "ubuntuProEnable": "Enable",
     "ubuntuProCancel": "Cancel",
     "ubuntuProFeatureEnableError": "Could not enable the feature, please try again.",

--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -288,6 +288,7 @@
     "ubuntuProDisablePro": "Disable Ubuntu Pro",
     "ubuntuProDisable": "Disable",
     "ubuntuProDisablePrompt": "Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?",
+    "ubuntuProDisableError": "Could not disable Ubuntu Pro. Please try again.",
     "ubuntuProEnable": "Enable",
     "ubuntuProCancel": "Cancel",
     "ubuntuProFeatureEnableError": "Could not enable the feature, please try again.",

--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -265,7 +265,7 @@
             }
         }
     },
-    "ubuntuProMagicError": "Unable to enable Ubuntu Pro, please try again",
+    "ubuntuProMagicError": "Unable to enable Ubuntu Pro, try again",
     "ubuntuProEnableToken": "Enable with a token",
     "ubuntuProEnableTokenError": "Unable to enable Ubuntu Pro",
     "ubuntuProEnableTokenSubtitle": "From your IT admin or from {proLink}",
@@ -288,11 +288,11 @@
     "ubuntuProDisablePro": "Disable Ubuntu Pro",
     "ubuntuProDisable": "Disable",
     "ubuntuProDisablePrompt": "Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?",
-    "ubuntuProDisableError": "Could not disable Ubuntu Pro. Please try again.",
+    "ubuntuProDisableError": "Could not disable Ubuntu Pro, try again",
     "ubuntuProEnable": "Enable",
     "ubuntuProCancel": "Cancel",
-    "ubuntuProFeatureEnableError": "Could not enable the feature, please try again.",
-    "ubuntuProFeatureDisableError": "Could not disable the feature, please try again.",
+    "ubuntuProFeatureEnableError": "Could not enable the feature, try again.",
+    "ubuntuProFeatureDisableError": "Could not disable the feature, try again.",
     "ubuntuProCompliance": "Compliance and hardening",
     "ubuntuProComplianceDisclaimer": "Only recommended to assist with FedRAMP, HIPAA and other compliance and hardening requirements.",
     "ubuntuProComplianceUSGTitle": "Ubuntu Security Guide (USG)",

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -1226,6 +1226,12 @@ abstract class AppLocalizations {
   /// **'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?'**
   String get ubuntuProDisablePrompt;
 
+  /// No description provided for @ubuntuProDisableError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not disable Ubuntu Pro. Please try again.'**
+  String get ubuntuProDisableError;
+
   /// No description provided for @ubuntuProEnable.
   ///
   /// In en, this message translates to:

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -1170,7 +1170,7 @@ abstract class AppLocalizations {
   /// No description provided for @ubuntuProMagicError.
   ///
   /// In en, this message translates to:
-  /// **'Unable to enable Ubuntu Pro, please try again'**
+  /// **'Unable to enable Ubuntu Pro, try again'**
   String get ubuntuProMagicError;
 
   /// No description provided for @ubuntuProEnableToken.
@@ -1224,7 +1224,7 @@ abstract class AppLocalizations {
   /// No description provided for @ubuntuProDisableError.
   ///
   /// In en, this message translates to:
-  /// **'Could not disable Ubuntu Pro. Please try again.'**
+  /// **'Could not disable Ubuntu Pro, try again'**
   String get ubuntuProDisableError;
 
   /// No description provided for @ubuntuProEnable.
@@ -1242,13 +1242,13 @@ abstract class AppLocalizations {
   /// No description provided for @ubuntuProFeatureEnableError.
   ///
   /// In en, this message translates to:
-  /// **'Could not enable the feature, please try again.'**
+  /// **'Could not enable the feature, try again.'**
   String get ubuntuProFeatureEnableError;
 
   /// No description provided for @ubuntuProFeatureDisableError.
   ///
   /// In en, this message translates to:
-  /// **'Could not disable the feature, please try again.'**
+  /// **'Could not disable the feature, try again.'**
   String get ubuntuProFeatureDisableError;
 
   /// No description provided for @ubuntuProCompliance.

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -1221,6 +1221,12 @@ abstract class AppLocalizations {
   /// **'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?'**
   String get ubuntuProDisablePrompt;
 
+  /// No description provided for @ubuntuProDisableError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not disable Ubuntu Pro. Please try again.'**
+  String get ubuntuProDisableError;
+
   /// No description provided for @ubuntuProEnable.
   ///
   /// In en, this message translates to:

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -598,6 +598,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -561,8 +561,7 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsAm extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -594,6 +594,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -603,6 +603,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -566,8 +566,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -599,8 +598,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -610,11 +608,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -599,6 +599,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -598,6 +598,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -594,6 +594,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -561,8 +561,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsBe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -598,6 +598,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -594,6 +594,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -561,8 +561,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -598,6 +598,10 @@ class AppLocalizationsBn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -561,8 +561,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsBn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -594,6 +594,10 @@ class AppLocalizationsBn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -598,6 +598,10 @@ class AppLocalizationsBo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -561,8 +561,7 @@ class AppLocalizationsBo extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsBo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -594,6 +594,10 @@ class AppLocalizationsBo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -598,6 +598,10 @@ class AppLocalizationsBs extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -567,8 +567,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -600,8 +599,7 @@ class AppLocalizationsBs extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -611,11 +609,11 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -600,6 +600,10 @@ class AppLocalizationsBs extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -611,6 +611,10 @@ class AppLocalizationsCa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -612,8 +612,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'Desactivant Ubuntu Pro se separarà la vostra subscripció d\'aquesta màquina. Voleu continuar?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Activa';

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -612,6 +612,10 @@ class AppLocalizationsCa extends AppLocalizations {
       'Desactivant Ubuntu Pro se separarà la vostra subscripció d\'aquesta màquina. Voleu continuar?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activa';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -604,6 +604,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zakázáním Ubuntu Pro se vaše předplatné odpojí od tohoto počítače. Chcete pokračovat?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Povolit';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -600,6 +600,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zakázáním Ubuntu Pro se vaše předplatné odpojí od tohoto počítače. Chcete pokračovat?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Povolit';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -600,8 +600,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zakázáním Ubuntu Pro se vaše předplatné odpojí od tohoto počítače. Chcete pokračovat?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Povolit';

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -598,6 +598,10 @@ class AppLocalizationsCy extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -561,8 +561,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsCy extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -594,6 +594,10 @@ class AppLocalizationsCy extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -598,6 +598,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -594,6 +594,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -561,8 +561,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -618,6 +618,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Durch die Deaktivierung von Ubuntu Pro wird Ihr Abonnement von diesem Gerät getrennt. Möchten Sie fortfahren?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktivieren';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -614,8 +614,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Durch die Deaktivierung von Ubuntu Pro wird Ihr Abonnement von diesem Gerät getrennt. Möchten Sie fortfahren?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Aktivieren';

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -614,6 +614,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Durch die Deaktivierung von Ubuntu Pro wird Ihr Abonnement von diesem Gerät getrennt. Möchten Sie fortfahren?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktivieren';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -598,6 +598,10 @@ class AppLocalizationsDz extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -594,6 +594,10 @@ class AppLocalizationsDz extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -561,8 +561,7 @@ class AppLocalizationsDz extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsDz extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsDz extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -617,6 +617,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Η απενεργοποίηση του Ubuntu Pro θα αποσυνδέσει τη συνδρομή σας από αυτό το μηχάνημα. Θέλετε να συνεχίσετε;';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Ενεργοποίηση';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -613,6 +613,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Η απενεργοποίηση του Ubuntu Pro θα αποσυνδέσει τη συνδρομή σας από αυτό το μηχάνημα. Θέλετε να συνεχίσετε;';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Ενεργοποίηση';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -613,8 +613,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Η απενεργοποίηση του Ubuntu Pro θα αποσυνδέσει τη συνδρομή σας από αυτό το μηχάνημα. Θέλετε να συνεχίσετε;';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Ενεργοποίηση';

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -598,6 +598,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -561,8 +561,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -594,6 +594,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -599,6 +599,10 @@ class AppLocalizationsEo extends AppLocalizations {
       'Malŝaltante Ubuntu Pro, vi dekroĉos vian abonon de ĉi tiu komputilo. Ĉu daŭrigi?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Ŝalti';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -595,8 +595,7 @@ class AppLocalizationsEo extends AppLocalizations {
       'Malŝaltante Ubuntu Pro, vi dekroĉos vian abonon de ĉi tiu komputilo. Ĉu daŭrigi?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Ŝalti';

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -595,6 +595,10 @@ class AppLocalizationsEo extends AppLocalizations {
       'Malŝaltante Ubuntu Pro, vi dekroĉos vian abonon de ĉi tiu komputilo. Ĉu daŭrigi?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Ŝalti';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -615,6 +615,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Si desactiva Ubuntu Pro, su suscripción dejará de estar asociada a este equipo. ¿Quiere continuar?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activar';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -610,8 +610,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Si desactiva Ubuntu Pro, su suscripción dejará de estar asociada a este equipo. ¿Quiere continuar?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Activar';

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -610,6 +610,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Si desactiva Ubuntu Pro, su suscripción dejará de estar asociada a este equipo. ¿Quiere continuar?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activar';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -604,6 +604,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Ubuntu Pro kasutuselt eemaldamisel eemaldatakse sellest masinast ka vastav tellimus. Kas sa soovid jätkata?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Lülita sisse';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -600,8 +600,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'Ubuntu Pro kasutuselt eemaldamisel eemaldatakse sellest masinast ka vastav tellimus. Kas sa soovid jätkata?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Lülita sisse';

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -600,6 +600,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Ubuntu Pro kasutuselt eemaldamisel eemaldatakse sellest masinast ka vastav tellimus. Kas sa soovid jätkata?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Lülita sisse';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -609,6 +609,10 @@ class AppLocalizationsEu extends AppLocalizations {
       'Ubuntu Pro ezgaitzen baduzu, makina hau harpidetzatik askatuko du. Jarraitu nahi duzu?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Gaitu';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -605,6 +605,10 @@ class AppLocalizationsEu extends AppLocalizations {
       'Ubuntu Pro ezgaitzen baduzu, makina hau harpidetzatik askatuko du. Jarraitu nahi duzu?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Gaitu';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -605,8 +605,7 @@ class AppLocalizationsEu extends AppLocalizations {
       'Ubuntu Pro ezgaitzen baduzu, makina hau harpidetzatik askatuko du. Jarraitu nahi duzu?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Gaitu';

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -598,6 +598,10 @@ class AppLocalizationsFa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -594,6 +594,10 @@ class AppLocalizationsFa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -561,8 +561,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -604,6 +604,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ubuntun Pro:n poistaminen käytöstä irrottaa tilauksesi tästä koneesta. Haluatko jatkaa?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Ota käyttöön';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -600,8 +600,7 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ubuntun Pro:n poistaminen käytöstä irrottaa tilauksesi tästä koneesta. Haluatko jatkaa?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Ota käyttöön';

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -600,6 +600,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ubuntun Pro:n poistaminen käytöstä irrottaa tilauksesi tästä koneesta. Haluatko jatkaa?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Ota käyttöön';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -615,6 +615,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Désactiver Ubuntu Pro détachera votre abonnement de cette machine. Voulez-vous continuer ?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activer';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -611,8 +611,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Désactiver Ubuntu Pro détachera votre abonnement de cette machine. Voulez-vous continuer ?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Activer';

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -611,6 +611,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Désactiver Ubuntu Pro détachera votre abonnement de cette machine. Voulez-vous continuer ?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activer';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -614,6 +614,10 @@ class AppLocalizationsGa extends AppLocalizations {
       'Má dhíchumasaíonn tú Ubuntu Pro, bainfear do shíntiús ón meaisín seo. Ar mhaith leat dul ar aghaidh?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Cumasaigh';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -610,6 +610,10 @@ class AppLocalizationsGa extends AppLocalizations {
       'Má dhíchumasaíonn tú Ubuntu Pro, bainfear do shíntiús ón meaisín seo. Ar mhaith leat dul ar aghaidh?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Cumasaigh';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -610,8 +610,7 @@ class AppLocalizationsGa extends AppLocalizations {
       'Má dhíchumasaíonn tú Ubuntu Pro, bainfear do shíntiús ón meaisín seo. Ar mhaith leat dul ar aghaidh?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Cumasaigh';

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -613,6 +613,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Desactivar Ubuntu Pro desvinculará a túa subscrición desta máquina. Queres continuar?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activar';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -609,8 +609,7 @@ class AppLocalizationsGl extends AppLocalizations {
       'Desactivar Ubuntu Pro desvinculará a túa subscrición desta máquina. Queres continuar?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Activar';

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -609,6 +609,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Desactivar Ubuntu Pro desvinculará a túa subscrición desta máquina. Queres continuar?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activar';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -598,6 +598,10 @@ class AppLocalizationsGu extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -561,8 +561,7 @@ class AppLocalizationsGu extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsGu extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -594,6 +594,10 @@ class AppLocalizationsGu extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -593,6 +593,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'השבתת Ubuntu Pro תנתק את המינוי שלך מהמכונה הזאת. להמשיך?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'הפעלה';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -589,8 +589,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'השבתת Ubuntu Pro תנתק את המינוי שלך מהמכונה הזאת. להמשיך?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'הפעלה';

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -589,6 +589,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'השבתת Ubuntu Pro תנתק את המינוי שלך מהמכונה הזאת. להמשיך?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'הפעלה';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -598,6 +598,10 @@ class AppLocalizationsHi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -561,8 +561,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsHi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -594,6 +594,10 @@ class AppLocalizationsHi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -598,6 +598,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -594,6 +594,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -561,8 +561,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -613,6 +613,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Az Ubuntu Pro letiltása leválasztja az előfizetését erről a számítógépről. Szeretné folytatni?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Engedélyezés';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -609,6 +609,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Az Ubuntu Pro letiltása leválasztja az előfizetését erről a számítógépről. Szeretné folytatni?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Engedélyezés';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -609,8 +609,7 @@ class AppLocalizationsHu extends AppLocalizations {
       'Az Ubuntu Pro letiltása leválasztja az előfizetését erről a számítógépről. Szeretné folytatni?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Engedélyezés';

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -602,6 +602,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -598,8 +598,7 @@ class AppLocalizationsId extends AppLocalizations {
       'Menonaktifkan Ubuntu Pro akan melepaskan langganan Anda dari mesin ini. Apakah Anda ingin melanjutkan?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Aktifkan';

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -598,6 +598,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Menonaktifkan Ubuntu Pro akan melepaskan langganan Anda dari mesin ini. Apakah Anda ingin melanjutkan?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktifkan';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -598,6 +598,10 @@ class AppLocalizationsIs extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -594,6 +594,10 @@ class AppLocalizationsIs extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -561,8 +561,7 @@ class AppLocalizationsIs extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsIs extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsIs extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -598,6 +598,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -594,6 +594,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -561,8 +561,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -571,6 +571,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'Ubuntu Proを無効にするとこのマシンをサブスクリプションから除外することになります。継続しますか？';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => '有効';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -567,8 +567,7 @@ class AppLocalizationsJa extends AppLocalizations {
       'Ubuntu Proを無効にするとこのマシンをサブスクリプションから除外することになります。継続しますか？';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => '有効';

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -567,6 +567,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'Ubuntu Proを無効にするとこのマシンをサブスクリプションから除外することになります。継続しますか？';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => '有効';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -608,6 +608,10 @@ class AppLocalizationsKa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -603,8 +603,7 @@ class AppLocalizationsKa extends AppLocalizations {
       'Ubuntu Pro-ის გამორთვა გააუქმებს ამ მანქანის გამოწერას. გააგრძელებთ?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'ჩართვა';

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -603,6 +603,10 @@ class AppLocalizationsKa extends AppLocalizations {
       'Ubuntu Pro-ის გამორთვა გააუქმებს ამ მანქანის გამოწერას. გააგრძელებთ?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'ჩართვა';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -598,6 +598,10 @@ class AppLocalizationsKk extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -594,6 +594,10 @@ class AppLocalizationsKk extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -561,8 +561,7 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsKk extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -598,6 +598,10 @@ class AppLocalizationsKm extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -561,8 +561,7 @@ class AppLocalizationsKm extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsKm extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -594,6 +594,10 @@ class AppLocalizationsKm extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -608,6 +608,10 @@ class AppLocalizationsKn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -604,6 +604,10 @@ class AppLocalizationsKn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -571,8 +571,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -604,8 +603,7 @@ class AppLocalizationsKn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -615,11 +613,11 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -580,6 +580,10 @@ class AppLocalizationsKo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -576,6 +576,10 @@ class AppLocalizationsKo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -543,8 +543,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -576,8 +575,7 @@ class AppLocalizationsKo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -587,11 +585,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -598,6 +598,10 @@ class AppLocalizationsKu extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -594,6 +594,10 @@ class AppLocalizationsKu extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -561,8 +561,7 @@ class AppLocalizationsKu extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsKu extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsKu extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -595,6 +595,10 @@ class AppLocalizationsLo extends AppLocalizations {
       'ການປິດໃຊ້ງານ Ubuntu Pro ຈະເປັນການຍົກເລີກການເຊື່ອມຕໍ່ການສະໝັກໃຊ້ຈາກເຄື່ອງນີ້. ທ່ານຕ້ອງການດຳເນີນການຕໍ່ຫຼືບໍ່?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'ເປີດໃຊ້ງານ';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -591,6 +591,10 @@ class AppLocalizationsLo extends AppLocalizations {
       'ການປິດໃຊ້ງານ Ubuntu Pro ຈະເປັນການຍົກເລີກການເຊື່ອມຕໍ່ການສະໝັກໃຊ້ຈາກເຄື່ອງນີ້. ທ່ານຕ້ອງການດຳເນີນການຕໍ່ຫຼືບໍ່?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'ເປີດໃຊ້ງານ';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -591,8 +591,7 @@ class AppLocalizationsLo extends AppLocalizations {
       'ການປິດໃຊ້ງານ Ubuntu Pro ຈະເປັນການຍົກເລີກການເຊື່ອມຕໍ່ການສະໝັກໃຊ້ຈາກເຄື່ອງນີ້. ທ່ານຕ້ອງການດຳເນີນການຕໍ່ຫຼືບໍ່?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'ເປີດໃຊ້ງານ';

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -598,6 +598,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -594,6 +594,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -561,8 +561,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsLt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -598,6 +598,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -594,6 +594,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -561,8 +561,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsLv extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -598,6 +598,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -561,8 +561,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsMk extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -594,6 +594,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -598,6 +598,10 @@ class AppLocalizationsMl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -561,8 +561,7 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsMl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -594,6 +594,10 @@ class AppLocalizationsMl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -598,6 +598,10 @@ class AppLocalizationsMr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -561,8 +561,7 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsMr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -594,6 +594,10 @@ class AppLocalizationsMr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -598,6 +598,10 @@ class AppLocalizationsMy extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -561,8 +561,7 @@ class AppLocalizationsMy extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsMy extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -594,6 +594,10 @@ class AppLocalizationsMy extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -598,6 +598,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -594,6 +594,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -561,8 +561,7 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -598,6 +598,10 @@ class AppLocalizationsNe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -594,6 +594,10 @@ class AppLocalizationsNe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -561,8 +561,7 @@ class AppLocalizationsNe extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsNe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -607,6 +607,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -570,8 +570,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -603,8 +602,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -614,11 +612,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -603,6 +603,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -598,6 +598,10 @@ class AppLocalizationsNn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -561,8 +561,7 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsNn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -594,6 +594,10 @@ class AppLocalizationsNn extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -613,6 +613,10 @@ class AppLocalizationsOc extends AppLocalizations {
       'Desactivar Ubuntu Pro destacarà vòstre abonament d\'aquesta maquina. Volètz contunhar ?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activar';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -609,8 +609,7 @@ class AppLocalizationsOc extends AppLocalizations {
       'Desactivar Ubuntu Pro destacarà vòstre abonament d\'aquesta maquina. Volètz contunhar ?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Activar';

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -609,6 +609,10 @@ class AppLocalizationsOc extends AppLocalizations {
       'Desactivar Ubuntu Pro destacarà vòstre abonament d\'aquesta maquina. Volètz contunhar ?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Activar';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -598,6 +598,10 @@ class AppLocalizationsPa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -594,6 +594,10 @@ class AppLocalizationsPa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -561,8 +561,7 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsPa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -608,6 +608,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wyłączenie Ubuntu Pro spowoduje odłączenie Twojej subskrypcji od tego komputera. Czy chcesz kontynuować?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Włącz';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -604,8 +604,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wyłączenie Ubuntu Pro spowoduje odłączenie Twojej subskrypcji od tego komputera. Czy chcesz kontynuować?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Włącz';

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -604,6 +604,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wyłączenie Ubuntu Pro spowoduje odłączenie Twojej subskrypcji od tego komputera. Czy chcesz kontynuować?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Włącz';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -608,6 +608,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -571,8 +571,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -604,8 +603,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -615,11 +613,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -604,6 +604,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -598,6 +598,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -594,6 +594,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -561,8 +561,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsRo extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -615,6 +615,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Отключение Ubuntu Pro отменит привязку подписки к этому компьютеру. Хотите продолжить?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Включить';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -611,6 +611,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Отключение Ubuntu Pro отменит привязку подписки к этому компьютеру. Хотите продолжить?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Включить';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -611,8 +611,7 @@ class AppLocalizationsRu extends AppLocalizations {
       'Отключение Ubuntu Pro отменит привязку подписки к этому компьютеру. Хотите продолжить?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Включить';

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -598,6 +598,10 @@ class AppLocalizationsSe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -594,6 +594,10 @@ class AppLocalizationsSe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -561,8 +561,7 @@ class AppLocalizationsSe extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsSe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsSe extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -598,6 +598,10 @@ class AppLocalizationsSi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -561,8 +561,7 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsSi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -594,6 +594,10 @@ class AppLocalizationsSi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -603,6 +603,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Deaktivovaním Ubuntu Pro sa toto zariadenie odpojí od vášho predplatného. Chcete pokračovať?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktivovať';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -601,8 +601,7 @@ class AppLocalizationsSk extends AppLocalizations {
       'Deaktivovaním Ubuntu Pro sa toto zariadenie odpojí od vášho predplatného. Chcete pokračovať?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Aktivovať';

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -601,6 +601,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Deaktivovaním Ubuntu Pro sa toto zariadenie odpojí od vášho predplatného. Chcete pokračovať?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktivovať';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -598,6 +598,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -594,6 +594,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -561,8 +561,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsSl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -598,6 +598,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -594,6 +594,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -561,8 +561,7 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsSq extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -598,6 +598,10 @@ class AppLocalizationsSr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -561,8 +561,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsSr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -594,6 +594,10 @@ class AppLocalizationsSr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -605,6 +605,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Att inaktivera Ubuntu Pro kommer att koppla bort din prenumeration från den här datorn. Vill du fortsätta?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktivera';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -601,8 +601,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Att inaktivera Ubuntu Pro kommer att koppla bort din prenumeration från den här datorn. Vill du fortsätta?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Aktivera';

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -601,6 +601,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Att inaktivera Ubuntu Pro kommer att koppla bort din prenumeration från den här datorn. Vill du fortsätta?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Aktivera';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -609,6 +609,10 @@ class AppLocalizationsTa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -605,6 +605,10 @@ class AppLocalizationsTa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -572,8 +572,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -605,8 +604,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -616,11 +614,11 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -598,6 +598,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -561,8 +561,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsTe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -594,6 +594,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -598,6 +598,10 @@ class AppLocalizationsTg extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -561,8 +561,7 @@ class AppLocalizationsTg extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsTg extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -594,6 +594,10 @@ class AppLocalizationsTg extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -598,6 +598,10 @@ class AppLocalizationsTh extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -561,8 +561,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsTh extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -594,6 +594,10 @@ class AppLocalizationsTh extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -598,6 +598,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -594,6 +594,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -561,8 +561,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsTl extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -606,6 +606,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -602,6 +602,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -569,8 +569,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -602,8 +601,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -613,11 +611,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -605,6 +605,10 @@ class AppLocalizationsUg extends AppLocalizations {
       'Ubuntu Pro نى چەكلىسىڭىز بۇ كومپيۇتېردىكى مۇشتەرىلىكىڭىز توختايدۇ. داۋاملاشتۇرامسىز؟';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'قوزغات';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -601,8 +601,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'Ubuntu Pro نى چەكلىسىڭىز بۇ كومپيۇتېردىكى مۇشتەرىلىكىڭىز توختايدۇ. داۋاملاشتۇرامسىز؟';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'قوزغات';

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -601,6 +601,10 @@ class AppLocalizationsUg extends AppLocalizations {
       'Ubuntu Pro نى چەكلىسىڭىز بۇ كومپيۇتېردىكى مۇشتەرىلىكىڭىز توختايدۇ. داۋاملاشتۇرامسىز؟';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'قوزغات';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -612,6 +612,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Вимкнення Ubuntu Pro від\'єднає вашу підписку від цього комп’ютера. Продовжити?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Увімкнути';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -608,8 +608,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Вимкнення Ubuntu Pro від\'єднає вашу підписку від цього комп’ютера. Продовжити?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Увімкнути';

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -608,6 +608,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Вимкнення Ubuntu Pro від\'єднає вашу підписку від цього комп’ютера. Продовжити?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Увімкнути';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -598,6 +598,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -594,6 +594,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -561,8 +561,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -594,8 +593,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -605,11 +603,11 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -566,6 +566,10 @@ class AppLocalizationsZh extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this machine. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -562,6 +562,10 @@ class AppLocalizationsZh extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
+  String get ubuntuProDisableError =>
+      'Could not disable Ubuntu Pro. Please try again.';
+
+  @override
   String get ubuntuProEnable => 'Enable';
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -529,8 +529,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get ubuntuProMagicError =>
-      'Unable to enable Ubuntu Pro, please try again';
+  String get ubuntuProMagicError => 'Unable to enable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnableToken => 'Enable with a token';
@@ -562,8 +561,7 @@ class AppLocalizationsZh extends AppLocalizations {
       'Disabling Ubuntu Pro will detach your subscription from this computer. Do you want to proceed?';
 
   @override
-  String get ubuntuProDisableError =>
-      'Could not disable Ubuntu Pro. Please try again.';
+  String get ubuntuProDisableError => 'Could not disable Ubuntu Pro, try again';
 
   @override
   String get ubuntuProEnable => 'Enable';
@@ -573,11 +571,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ubuntuProFeatureEnableError =>
-      'Could not enable the feature, please try again.';
+      'Could not enable the feature, try again.';
 
   @override
   String get ubuntuProFeatureDisableError =>
-      'Could not disable the feature, please try again.';
+      'Could not disable the feature, try again.';
 
   @override
   String get ubuntuProCompliance => 'Compliance and hardening';

--- a/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
+++ b/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
@@ -60,6 +60,13 @@ class DetachDialog extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(l10n.ubuntuProDisablePrompt),
+            if (provider.state is UbuntuProAttachStateError) ...[
+              const SizedBox(height: 8),
+              YaruInfoBox(
+                subtitle: Text(l10n.ubuntuProDisableError),
+                yaruInfoType: YaruInfoType.danger,
+              ),
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
Detach errors are very unlikely and we can't obtain much information about the cause of failure, but previously they were silently dropped. This shows a generic error message in the detach dialog if detaching fails.

<img width="904" height="704" alt="image" src="https://github.com/user-attachments/assets/d6026902-721d-4ca9-9b6d-779c817bc852" />

---

UDENG-9316