### PR TITLE
fix: check for error after snapd change is ready

### DIFF
--- a/packages/security_center/lib/services/snapd_app_permissions_service.dart
+++ b/packages/security_center/lib/services/snapd_app_permissions_service.dart
@@ -164,12 +164,13 @@ class SnapdAppPermissionsService implements AppPermissionsService {
       await for (final change in _snapd.watchChange(changeId)) {
         _log.debug('Change: $change');
         if (change.ready) {
-          break;
-        } else if (change.err != null) {
-          _log.error(
-            'Snapd change $changeId completed with an error: ${change.err}',
-          );
-          _emitStatus(AppPermissionsServiceStatus.error(change.err!));
+          // Changes which result in an error become "ready" when error is set
+          if (change.err != null) {
+            _log.error(
+              'Snapd change $changeId completed with an error: ${change.err}',
+            );
+            _emitStatus(AppPermissionsServiceStatus.error(change.err!));
+          }
           break;
         }
         _emitStatus(progressState(change.progress));

--- a/packages/security_center/lib/services/snapd_app_permissions_service.dart
+++ b/packages/security_center/lib/services/snapd_app_permissions_service.dart
@@ -170,6 +170,7 @@ class SnapdAppPermissionsService implements AppPermissionsService {
               'Snapd change $changeId completed with an error: ${change.err}',
             );
             _emitStatus(AppPermissionsServiceStatus.error(change.err!));
+            return;
           }
           break;
         }

--- a/packages/security_center/test/services/snapd_app_permissions_service_test.dart
+++ b/packages/security_center/test/services/snapd_app_permissions_service_test.dart
@@ -135,6 +135,7 @@ void main() {
       bool enabled,
       Future<void> Function(AppPermissionsService) callback,
       bool authCancelled,
+      String? changeErr,
       List<AppPermissionsServiceStatus> expectedStatuses
     })>[
       // The mock service doesn't have a mutable state, so it will return the
@@ -146,6 +147,7 @@ void main() {
         enabled: true,
         callback: (service) => service.enable(),
         authCancelled: false,
+        changeErr: null,
         expectedStatuses: [
           AppPermissionsServiceStatus.enabled([]),
           AppPermissionsServiceStatus.waitingForAuth(),
@@ -159,6 +161,7 @@ void main() {
         enabled: false,
         callback: (service) => service.disable(),
         authCancelled: false,
+        changeErr: null,
         expectedStatuses: [
           AppPermissionsServiceStatus.disabled(),
           AppPermissionsServiceStatus.waitingForAuth(),
@@ -172,10 +175,25 @@ void main() {
         enabled: false,
         callback: (service) => service.enable(),
         authCancelled: true,
+        changeErr: null,
         expectedStatuses: [
           AppPermissionsServiceStatus.disabled(),
           AppPermissionsServiceStatus.waitingForAuth(),
           AppPermissionsServiceStatus.disabled(),
+        ],
+      ),
+      (
+        name: 'error when enabling',
+        enabled: false,
+        callback: (service) => service.enable(),
+        authCancelled: false,
+        changeErr: 'snapd change error',
+        expectedStatuses: [
+          AppPermissionsServiceStatus.disabled(),
+          AppPermissionsServiceStatus.waitingForAuth(),
+          AppPermissionsServiceStatus.enabling(0.0),
+          AppPermissionsServiceStatus.enabling(0.5),
+          AppPermissionsServiceStatus.error('snapd change error'),
         ],
       ),
     ];
@@ -186,7 +204,7 @@ void main() {
           registerMockSnapdService(
             promptingEnabled: testCase.enabled,
             changeId: 'changeId',
-            changes: const [
+            changes: [
               SnapdChange(
                 id: 'changeId',
                 tasks: [
@@ -205,6 +223,7 @@ void main() {
                     progress: SnapdTaskProgress(done: 2, total: 2),
                   ),
                 ],
+                err: testCase.changeErr,
               ),
             ],
             authCancelled: testCase.authCancelled,


### PR DESCRIPTION
Snapd changes become "ready" when they complete and their status is ready to be checked. When a change errors, it becomes ready as well, since an error status is just another status. Thus, check `change.err` only after `change.ready` is true, and do not assume that just because a change is ready that no error occurred.

This is an attempt to address https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2144624