### PR TITLE
fix: ubuntu-pro-control needs snapd2.75

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ license: GPL-3.0
 grade: stable
 confinement: strict
 compression: lzo
+assumes:
+  - snapd2.75
 
 apps:
   desktop-security-center:


### PR DESCRIPTION
Without snapd 2.75, the system will warn:
> snap “desktop-security-center” has bad plugs or slots: ubuntu-pro-control (unknown interface “ubuntu-pro-control”)

Also the function won't work as expected.

This PR resolves #195 