### PR TITLE
feat: show error message if enabling prompting fails

### DIFF
--- a/packages/security_center/lib/app_permissions/interfaces_page.dart
+++ b/packages/security_center/lib/app_permissions/interfaces_page.dart
@@ -34,6 +34,13 @@ class _Body extends StatelessWidget {
       children: [
         ...[
           _PromptingSwitch(promptingStatus: promptingStatus),
+          if (promptingStatus
+              case AppPermissionsServiceStatusError(error: final error))
+            YaruInfoBox(
+              yaruInfoType: YaruInfoType.danger,
+              title: Text(l10n.snapPermissionsErrorTitle),
+              child: Text(error.toString()),
+            ),
           Text(l10n.interfacePageDescription),
           const _Links(),
         ].separatedBy(const SizedBox(height: 8)),
@@ -131,6 +138,7 @@ class _PromptingSwitch extends ConsumerWidget {
             ),
             value: promptingStatus.isEnabled || promptingStatus.isEnabling,
             onChanged: switch (promptingStatus) {
+              AppPermissionsServiceStatusError() ||
               AppPermissionsServiceStatusDisabled() ||
               AppPermissionsServiceStatusEnabled() =>
                 (value) => value ? notifier.enable() : notifier.disable(),

--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -32,6 +32,7 @@
     "@snapPermissionsOtherDescription": {},
     "snapPermissionsPageTitle": "App permissions",
     "@snapPermissionsPageTitle": {},
+    "snapPermissionsErrorTitle": "Something went wrong",
     "snapRulesCount": "{n, plural, =0{no rules} =1{1 rule} other{{n} rules}}",
     "@snapRulesCount": {
         "placeholders": {

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -338,6 +338,12 @@ abstract class AppLocalizations {
   /// **'App permissions'**
   String get snapPermissionsPageTitle;
 
+  /// No description provided for @snapPermissionsErrorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get snapPermissionsErrorTitle;
+
   /// No description provided for @snapRulesCount.
   ///
   /// In en, this message translates to:

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -62,6 +62,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -62,6 +62,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get snapPermissionsPageTitle => 'أذونات التطبيق';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -62,6 +62,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -62,6 +62,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -62,6 +62,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -62,6 +62,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -62,6 +62,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -64,6 +64,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Permisos de l\'aplicació';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -62,6 +62,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Oprávnění aplikací';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -62,6 +62,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -62,6 +62,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Programrettigheder';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -62,6 +62,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App-Berechtigungen';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -62,6 +62,9 @@ class AppLocalizationsDz extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -64,6 +64,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Άδειες Εφαρμογής';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -62,6 +62,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -62,6 +62,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Programaj permesoj';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -62,6 +62,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Permisos de la aplicación';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -62,6 +62,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Rakenduste õigused';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -62,6 +62,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Aplikazioaren baimenak';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -62,6 +62,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'اجازه‌های کاره';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -62,6 +62,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Sovelluksen oikeudet';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -64,6 +64,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Permissions d\'app';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -63,6 +63,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Ceadanna aipeanna';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -62,6 +62,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Permisos da aplicación';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -62,6 +62,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -61,6 +61,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get snapPermissionsPageTitle => 'הרשאות יישום';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -62,6 +62,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -62,6 +62,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -63,6 +63,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Alkalmazás jogosultságai';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -62,6 +62,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Izin Aplikasi';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -62,6 +62,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -62,6 +62,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Permessi delle app';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -58,6 +58,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'アプリのパーミッション';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -62,6 +62,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'აპის წვდომები';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -62,6 +62,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -62,6 +62,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -62,6 +62,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get snapPermissionsPageTitle => 'ಅಪ್ಲಿಕೇಶನ್ ಅನುಮತಿಗಳು';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -58,6 +58,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get snapPermissionsPageTitle => '앱 권한';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -62,6 +62,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -62,6 +62,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get snapPermissionsPageTitle => 'ການອະນຸຍາດແອັບ';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -62,6 +62,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -62,6 +62,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -62,6 +62,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -62,6 +62,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -62,6 +62,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -62,6 +62,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -62,6 +62,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Programtilganger';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -62,6 +62,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -62,6 +62,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App-machtigingen';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -62,6 +62,9 @@ class AppLocalizationsNn extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -62,6 +62,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Autorizacions de l’aplicacion';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -62,6 +62,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -64,6 +64,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Uprawnienia programów';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -63,6 +63,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Permissões de Aplicação';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -62,6 +62,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -63,6 +63,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Разрешения приложений';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -62,6 +62,9 @@ class AppLocalizationsSe extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -62,6 +62,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -61,6 +61,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Oprávnenia aplikácie';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -62,6 +62,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -62,6 +62,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -62,6 +62,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Дозволе апликација';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -62,6 +62,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Programbehörigheter';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -62,6 +62,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get snapPermissionsPageTitle => 'பயன்பாட்டு இசைவுகள்';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -62,6 +62,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -62,6 +62,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -62,6 +62,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -62,6 +62,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -62,6 +62,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Uygulama İzinleri';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -62,6 +62,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get snapPermissionsPageTitle => 'ئەپ ئىجازىتى';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -62,6 +62,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get snapPermissionsPageTitle => 'Дозволи застосунків';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -62,6 +62,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get snapPermissionsPageTitle => 'App permissions';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -57,6 +57,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get snapPermissionsPageTitle => '应用程序权限';
 
   @override
+  String get snapPermissionsErrorTitle => 'Something went wrong';
+
+  @override
   String snapRulesCount(int n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/packages/security_center/test/app_permissions/interfaces_page_test.dart
+++ b/packages/security_center/test/app_permissions/interfaces_page_test.dart
@@ -217,5 +217,27 @@ void main() {
         });
       }
     });
+    testWidgets('error state', (tester) async {
+      final container = createContainer();
+      registerMockAppPermissionsService();
+      await tester.pumpApp(
+        (_) => UncontrolledProviderScope(
+          container: container,
+          child: const InterfacesPage(),
+        ),
+      );
+      container.read(promptingStatusModelProvider.notifier).state =
+          AsyncData(AppPermissionsServiceStatusError('snapd error'));
+      await tester.pump();
+
+      expect(
+        find.text('snapd error'),
+        findsOneWidget,
+      );
+      expect(
+        find.text(tester.l10n.snapPermissionsErrorTitle),
+        findsOneWidget,
+      );
+    });
   });
 }


### PR DESCRIPTION
Follow-up to #204

Since snapd changes don't include error kinds, we display the raw error message here. The toggle button remains in the 'off' state but stays interactive, so that the user can try enabling the feature again.

<img width="1808" height="1408" alt="Screenshot From 2026-04-27 15-35-58" src="https://github.com/user-attachments/assets/1e5a60e5-a27b-42c4-be93-beacaa970f38" />


UDENG-9860