### PR TITLE
fix(ubuntu-pro): update ESM description copy

### DIFF
--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -309,9 +309,9 @@
     "ubuntuProComplianceFIPSNoUpdatesDescription": "Installs FIPS 140-2 validated packages. These will not be updated until the next recertification.",
     "ubuntuProComplianceDocumentation": "Security compliance documentation",
     "ubuntuProESMTitle": "Expanded Security Maintenance (ESM)",
-    "ubuntuProESMDescription": "ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.",
+    "ubuntuProESMDescription": "ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.",
     "ubuntuProESMMainTitle": "Main packages (esm-infra)",
-    "ubuntuProESMMainDescription": "Security updates for 2,300 Ubuntu Main package until {year}",
+    "ubuntuProESMMainDescription": "Security updates for Ubuntu Main packages until {year}",
     "@ubuntuProESMMainDescription": {
         "placeholders": {
             "year": {
@@ -320,7 +320,7 @@
         }
     },
     "ubuntuProESMUniverseTitle": "Universe packages (esm-apps)",
-    "ubuntuProESMUniverseDescription": "Additional security updates for over 23,000 Ubuntu Universe packages until {year}",
+    "ubuntuProESMUniverseDescription": "Additional security updates for Ubuntu Universe packages until {year}",
     "@ubuntuProESMUniverseDescription": {
         "placeholders": {
             "year": {

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -1343,7 +1343,7 @@ abstract class AppLocalizations {
   /// No description provided for @ubuntuProESMDescription.
   ///
   /// In en, this message translates to:
-  /// **'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.'**
+  /// **'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.'**
   String get ubuntuProESMDescription;
 
   /// No description provided for @ubuntuProESMMainTitle.
@@ -1355,7 +1355,7 @@ abstract class AppLocalizations {
   /// No description provided for @ubuntuProESMMainDescription.
   ///
   /// In en, this message translates to:
-  /// **'Security updates for 2,300 Ubuntu Main package until {year}'**
+  /// **'Security updates for Ubuntu Main packages until {year}'**
   String ubuntuProESMMainDescription(int year);
 
   /// No description provided for @ubuntuProESMUniverseTitle.
@@ -1367,7 +1367,7 @@ abstract class AppLocalizations {
   /// No description provided for @ubuntuProESMUniverseDescription.
   ///
   /// In en, this message translates to:
-  /// **'Additional security updates for over 23,000 Ubuntu Universe packages until {year}'**
+  /// **'Additional security updates for Ubuntu Universe packages until {year}'**
   String ubuntuProESMUniverseDescription(int year);
 
   /// No description provided for @ubuntuProLivepatchTitle.

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -666,14 +666,14 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -671,14 +671,14 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -686,7 +686,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -666,14 +666,14 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -666,14 +666,14 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -666,14 +666,14 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -666,14 +666,14 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsBo extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -666,14 +666,14 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -679,14 +679,14 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -694,7 +694,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -666,14 +666,14 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -666,14 +666,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -666,14 +666,14 @@ class AppLocalizationsDz extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsDz extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -666,14 +666,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -666,14 +666,14 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -666,14 +666,14 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -660,7 +660,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'חבילות עיקריות (esm-infra)';

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -666,14 +666,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -666,14 +666,14 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -670,14 +670,14 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -685,7 +685,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -666,14 +666,14 @@ class AppLocalizationsIs extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsIs extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -666,14 +666,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -676,14 +676,14 @@ class AppLocalizationsKa extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -691,7 +691,7 @@ class AppLocalizationsKa extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -666,14 +666,14 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -666,14 +666,14 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -676,14 +676,14 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -691,7 +691,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -648,14 +648,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -663,7 +663,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -666,14 +666,14 @@ class AppLocalizationsKu extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsKu extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -666,14 +666,14 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -666,14 +666,14 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -666,14 +666,14 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -666,14 +666,14 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -666,14 +666,14 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -666,14 +666,14 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -666,14 +666,14 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -666,14 +666,14 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -675,14 +675,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -690,7 +690,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -666,14 +666,14 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -666,14 +666,14 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -676,14 +676,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -691,7 +691,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -666,14 +666,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -666,14 +666,14 @@ class AppLocalizationsSe extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsSe extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -666,14 +666,14 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -666,14 +666,14 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -666,14 +666,14 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -666,14 +666,14 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -677,14 +677,14 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -692,7 +692,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -666,14 +666,14 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -666,14 +666,14 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -666,14 +666,14 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -666,14 +666,14 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -674,14 +674,14 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -689,7 +689,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -674,14 +674,14 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -689,7 +689,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -666,14 +666,14 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -681,7 +681,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -634,14 +634,14 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get ubuntuProESMDescription =>
-      'ESM provides 10 years of security patches for 25,000+ open source packages. Get continuous vulnerability management for critical, high, and medium CVEs.';
+      'ESM provides 10 years of security patches for the entire Ubuntu Archive. Get continuous vulnerability management for critical, high and selected medium CVEs.';
 
   @override
   String get ubuntuProESMMainTitle => 'Main packages (esm-infra)';
 
   @override
   String ubuntuProESMMainDescription(int year) {
-    return 'Security updates for 2,300 Ubuntu Main package until $year';
+    return 'Security updates for Ubuntu Main packages until $year';
   }
 
   @override
@@ -649,7 +649,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String ubuntuProESMUniverseDescription(int year) {
-    return 'Additional security updates for over 23,000 Ubuntu Universe packages until $year';
+    return 'Additional security updates for Ubuntu Universe packages until $year';
   }
 
   @override


### PR DESCRIPTION
Update ESM section copy to remove specific package counts that could become stale, and align wording with current Ubuntu Pro marketing.

UDENG-9902

## Type of Change
Documentation update (UI copy / localisation strings)