### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,15 +2,12 @@ name: Bug report for the Security Center
 description: Create a report to help us improve
 labels:
   - bug
-assignees:
-  - d-loose
-  - juanruitina
 body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please search to see if an issue already exists for this feature: https://github.com/canonical/desktop-security-center/issues.
+      Please search to see if an issue already exists for this bug: https://github.com/canonical/desktop-security-center/issues.
     options:
     - label: I have searched the existing issues
       required: true
@@ -39,25 +36,10 @@ body:
       A clear and concise description of what you expected to happen.
   validations:
     required: false
-- type: dropdown
+- type: input
   attributes:
     label: Ubuntu release
-    description: What version of our Ubuntu are you running?
-    options:
-      - '24.10'
-      - 24.04 LTS
-      - Other (specify in the last field)
-  validations:
-    required: false
-- type: dropdown
-  attributes:
-    label: What architecture are you using?
-    multiple: false
-    options:
-      - amd64
-      - arm64
-      - Other (specify in the last field)
-      - I don't know
+    description: What version of Ubuntu are you running? E.g. '26.04 LTS'. You can find it in Settings > About, or by running `lsb_release -d` in the terminal.
   validations:
     required: false
 - type: textarea
@@ -65,7 +47,7 @@ body:
     label: System info
     description: |
       Please run this command in your terminal:
-      ```uname -rv && snap info snapd prompting-client desktop-security-center```
+      ```uname -rvm && snap info snapd prompting-client desktop-security-center```
       and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_prompts.yml
@@ -3,16 +3,12 @@ description: Issues with prompts and specific apps? Let us know.
 labels:
   - bug
   - prompting
-assignees:
-  - d-loose
-  - matthew-hagemann
-  - juanruitina
 body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please search to see if an issue already exists for this feature: https://github.com/canonical/desktop-security-center/issues.
+      Please search to see if an issue already exists for this bug: https://github.com/canonical/desktop-security-center/issues.
     options:
     - label: I have searched the existing issues
       required: true
@@ -41,25 +37,10 @@ body:
       A clear and concise description of what you expected to happen.
   validations:
     required: false
-- type: dropdown
+- type: input
   attributes:
     label: Ubuntu release
-    description: What version of our Ubuntu are you running?
-    options:
-      - '24.10'
-      - 24.04 LTS
-      - Other (specify in the last field)
-  validations:
-    required: false
-- type: dropdown
-  attributes:
-    label: What architecture are you using?
-    multiple: false
-    options:
-      - amd64
-      - arm64
-      - Other (specify in the last field)
-      - I don't know
+    description: What version of Ubuntu are you running? E.g. '26.04 LTS'. You can find it in Settings > About, or by running `lsb_release -d` in the terminal.
   validations:
     required: false
 - type: textarea
@@ -67,7 +48,7 @@ body:
     label: System info
     description: |
       Please run this command in your terminal:
-      ```uname -rv && snap info snapd prompting-client desktop-security-center```
+      ```uname -rvm && snap info snapd prompting-client desktop-security-center```
       and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,8 +2,6 @@ name: Feature request
 description: Suggest an idea for the Security Center
 labels:
   - enhancement
-assignees:
-  - juanruitina
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
- Remove auto-assignees from all templates
- Replace Ubuntu release dropdown with a free-text input and update its description
- Remove architecture dropdown (covered by the System info command output)

UDENG-10151