### PR TITLE
Fix KDE Plasma taskbar icon matching

### DIFF
--- a/snap/gui/desktop-security-center.desktop
+++ b/snap/gui/desktop-security-center.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Version=1.0
 Exec=desktop-security-center %U
-Icon=${SNAP}/meta/gui/security-center.svg
+Icon=${SNAP}/meta/gui/desktop-security-center.png
 StartupWMClass=security_center
 Terminal=false
 Categories=System;Utility;Permissions;Settings;Security;

--- a/snap/gui/desktop-security-center.desktop
+++ b/snap/gui/desktop-security-center.desktop
@@ -2,7 +2,8 @@
 Type=Application
 Version=1.0
 Exec=desktop-security-center %U
-Icon=${SNAP}/meta/gui/desktop-security-center.png
+Icon=${SNAP}/meta/gui/security-center.svg
+StartupWMClass=security_center
 Terminal=false
 Categories=System;Utility;Permissions;Settings;Security;
 Keywords=Ubuntu;Permissions;Snaps;Security;Pro;


### PR DESCRIPTION
## Summary

KDE Plasma may show a generic Wayland placeholder icon for Security Center in the taskbar instead of the correct application icon.

This happens because the running window reports:

* `desktopFile: security_center`
* `resourceClass: security_center`
* `resourceName: security_center`

but the desktop entry does not declare a matching `StartupWMClass`.

This PR adds:

```ini
StartupWMClass=security_center
```

so Plasma can correctly associate the running window with its desktop entry and icon.

## Testing

Tested locally on:

* KDE Plasma
* Wayland
* Ubuntu Studio 26.04

Verified that:

* the correct taskbar icon is shown
* the generic Wayland placeholder icon no longer appears
* launcher/taskbar grouping works correctly
