### PR TITLE
Uniquely handle polkit errors using snapd reported error kinds

### DIFF
--- a/packages/security_center/lib/disk_encryption/disk_encryption_l10n.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_l10n.dart
@@ -44,6 +44,14 @@ extension SnapdStateExceptionL10n on SnapdStateException {
       };
 }
 
+extension TpmFdeOperationExceptionMessage on TpmFdeOperationException {
+  String causeByMessage() => switch (this) {
+        TpmFdeOperationSnapdAuthException(:final cause) => cause.message,
+        TpmFdeOperationSnapdException(:final cause) => cause.message,
+        TpmFdeOperationUnknownException(:final cause) => cause.toString(),
+      };
+}
+
 extension TpmStateExceptionL10n on TpmStateException {
   String localizedHeader(AppLocalizations l10n) => switch (this) {
         TpmStateExceptionFailed() =>

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -89,7 +89,7 @@ class EncryptionPageBody extends ConsumerWidget {
             yaruInfoType: YaruInfoType.danger,
           ),
         _ => YaruInfoBox(
-            title: Text(l10n.diskEncryptionPageError),
+            title: Text(l10n.recoveryKeySomethingWentWrongHeader),
             subtitle: Text(e.toString()),
             yaruInfoType: YaruInfoType.danger,
           ),
@@ -452,9 +452,11 @@ class ChangeAuthDialog extends ConsumerWidget {
     return AlertDialog(
       title: YaruDialogTitleBar(title: Text(title)),
       titlePadding: EdgeInsets.zero,
+      contentPadding: EdgeInsets.zero,
       content: SizedBox(
         width: 460,
         child: ScrollablePage(
+          padding: const EdgeInsets.all(24),
           children: [
             CurrentPassphraseFormField(authMode: authMode),
             PassphraseFormField(authMode: authMode),
@@ -494,9 +496,7 @@ class ChangeAuthDialog extends ConsumerWidget {
               ),
             if (model.dialogState is ChangeAuthDialogStateError)
               YaruInfoBox(
-                title: (model.dialogState as ChangeAuthDialogStateError).fatal
-                    ? Text(l10n.recoveryKeySomethingWentWrongHeader)
-                    : Text(l10n.diskEncryptionPageError),
+                title: Text(l10n.recoveryKeySomethingWentWrongHeader),
                 subtitle: Text(
                   _dialogErrorMessage(
                     (model.dialogState as ChangeAuthDialogStateError).e,
@@ -571,11 +571,13 @@ class ChangeAuthModeDialog extends ConsumerWidget {
     return AlertDialog(
       title: YaruDialogTitleBar(title: Text(title)),
       titlePadding: EdgeInsets.zero,
+      contentPadding: EdgeInsets.zero,
       insetPadding:
           const EdgeInsets.symmetric(horizontal: 40.0, vertical: 16.0),
       content: SizedBox(
         width: 460,
         child: ScrollablePage(
+          padding: const EdgeInsets.all(24),
           children: [
             Text(bodyMainText),
             Text(bodyRecoveryText),
@@ -590,14 +592,9 @@ class ChangeAuthModeDialog extends ConsumerWidget {
                 ),
               ],
             ),
-            if (model.dialogState
-                case ChangeAuthModeDialogStateError(:final e, :final fatal))
+            if (model.dialogState case ChangeAuthModeDialogStateError(:final e))
               YaruInfoBox(
-                title: Text(
-                  fatal
-                      ? l10n.recoveryKeySomethingWentWrongHeader
-                      : l10n.diskEncryptionPageError,
-                ),
+                title: Text(l10n.recoveryKeySomethingWentWrongHeader),
                 subtitle: Text(_dialogErrorMessage(e)),
                 yaruInfoType: YaruInfoType.danger,
               ),
@@ -704,7 +701,7 @@ class _NoneAuthenticationActions extends ConsumerWidget {
         if (hasError) ...[
           const SizedBox(height: 8),
           YaruInfoBox(
-            title: Text(l10n.diskEncryptionPageError),
+            title: Text(l10n.recoveryKeySomethingWentWrongHeader),
             subtitle: Text(
               tpmState.operationError!.causeByMessage(),
             ),
@@ -771,7 +768,7 @@ class _PassphraseAuthenticationActions extends ConsumerWidget {
         if (hasError) ...[
           const SizedBox(height: 8),
           YaruInfoBox(
-            title: Text(l10n.diskEncryptionPageError),
+            title: Text(l10n.recoveryKeySomethingWentWrongHeader),
             subtitle: Text(
               tpmState.operationError!.causeByMessage(),
             ),
@@ -833,7 +830,7 @@ class _PinAuthenticationActions extends ConsumerWidget {
         if (hasError) ...[
           const SizedBox(height: 8),
           YaruInfoBox(
-            title: Text(l10n.diskEncryptionPageError),
+            title: Text(l10n.recoveryKeySomethingWentWrongHeader),
             subtitle: Text(
               tpmState.operationError!.causeByMessage(),
             ),

--- a/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_page.dart
@@ -18,6 +18,11 @@ const defaultRecoveryKeyFileName = 'recovery-key.txt';
 
 const yaruProgressSize = 20.0;
 
+String _dialogErrorMessage(Exception e) => switch (e) {
+      final TpmFdeOperationException e => e.causeByMessage(),
+      _ => e.toString(),
+    };
+
 class DiskEncryptionPage extends ConsumerWidget {
   const DiskEncryptionPage({super.key});
 
@@ -493,9 +498,9 @@ class ChangeAuthDialog extends ConsumerWidget {
                     ? Text(l10n.recoveryKeySomethingWentWrongHeader)
                     : Text(l10n.diskEncryptionPageError),
                 subtitle: Text(
-                  (model.dialogState as ChangeAuthDialogStateError)
-                      .e
-                      .toString(),
+                  _dialogErrorMessage(
+                    (model.dialogState as ChangeAuthDialogStateError).e,
+                  ),
                 ),
                 yaruInfoType: YaruInfoType.danger,
               ),
@@ -551,6 +556,18 @@ class ChangeAuthModeDialog extends ConsumerWidget {
       _ => '',
     };
 
+    final canSave =
+        model.dialogState is ChangeAuthModeDialogStateInput && notifier.isValid;
+
+    Future<void> handleSubmit() async {
+      final navigator = Navigator.of(context);
+      await notifier.replaceAuthMode(
+        onAuthorized: () {
+          if (navigator.mounted) navigator.pop();
+        },
+      );
+    }
+
     return AlertDialog(
       title: YaruDialogTitleBar(title: Text(title)),
       titlePadding: EdgeInsets.zero,
@@ -568,28 +585,20 @@ class ChangeAuthModeDialog extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 ElevatedButton(
-                  onPressed:
-                      model.dialogState is ChangeAuthModeDialogStateInput &&
-                              notifier.isValid
-                          ? () {
-                              Navigator.of(context).pop();
-                              notifier.replaceAuthMode();
-                            }
-                          : null,
+                  onPressed: canSave ? handleSubmit : null,
                   child: Text(l10n.diskEncryptionPageAddPinDialogSaveButton),
                 ),
               ],
             ),
-            // Show fatal errors in dialog (like entropy check failures)
-            if (model.dialogState is ChangeAuthModeDialogStateError &&
-                (model.dialogState as ChangeAuthModeDialogStateError).fatal)
+            if (model.dialogState
+                case ChangeAuthModeDialogStateError(:final e, :final fatal))
               YaruInfoBox(
-                title: Text(l10n.recoveryKeySomethingWentWrongHeader),
-                subtitle: Text(
-                  (model.dialogState as ChangeAuthModeDialogStateError)
-                      .e
-                      .toString(),
+                title: Text(
+                  fatal
+                      ? l10n.recoveryKeySomethingWentWrongHeader
+                      : l10n.diskEncryptionPageError,
                 ),
+                subtitle: Text(_dialogErrorMessage(e)),
                 yaruInfoType: YaruInfoType.danger,
               ),
           ].separatedBy(const SizedBox(height: 16)),
@@ -642,7 +651,10 @@ class _NoneAuthenticationActions extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final isAdding = tpmState.pendingOperation is AuthOperationAdding;
+    final isAdding = switch (tpmState.pendingOperation) {
+      TpmFdeOperation.addPin || TpmFdeOperation.addPassphrase => true,
+      _ => false,
+    };
     final hasError = tpmState.operationError != null;
 
     return Column(
@@ -693,7 +705,9 @@ class _NoneAuthenticationActions extends ConsumerWidget {
           const SizedBox(height: 8),
           YaruInfoBox(
             title: Text(l10n.diskEncryptionPageError),
-            subtitle: Text(tpmState.operationError.toString()),
+            subtitle: Text(
+              tpmState.operationError!.causeByMessage(),
+            ),
             yaruInfoType: YaruInfoType.danger,
           ),
         ],
@@ -710,7 +724,10 @@ class _PassphraseAuthenticationActions extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final isRemoving = tpmState.pendingOperation is AuthOperationRemoving;
+    final isRemoving = switch (tpmState.pendingOperation) {
+      TpmFdeOperation.removePin || TpmFdeOperation.removePassphrase => true,
+      _ => false,
+    };
     final hasError = tpmState.operationError != null;
 
     return Column(
@@ -743,7 +760,7 @@ class _PassphraseAuthenticationActions extends ConsumerWidget {
                   : () {
                       ref
                           .read(tpmAuthenticationModelProvider.notifier)
-                          .changeAuthMode(AuthMode.none);
+                          .removeAuthMode();
                     },
               child: Text(
                 l10n.diskEncryptionPageRemovePassphraseButton,
@@ -755,7 +772,9 @@ class _PassphraseAuthenticationActions extends ConsumerWidget {
           const SizedBox(height: 8),
           YaruInfoBox(
             title: Text(l10n.diskEncryptionPageError),
-            subtitle: Text(tpmState.operationError.toString()),
+            subtitle: Text(
+              tpmState.operationError!.causeByMessage(),
+            ),
             yaruInfoType: YaruInfoType.danger,
           ),
         ],
@@ -772,7 +791,10 @@ class _PinAuthenticationActions extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final isRemoving = tpmState.pendingOperation is AuthOperationRemoving;
+    final isRemoving = switch (tpmState.pendingOperation) {
+      TpmFdeOperation.removePin || TpmFdeOperation.removePassphrase => true,
+      _ => false,
+    };
     final hasError = tpmState.operationError != null;
 
     return Column(
@@ -802,7 +824,7 @@ class _PinAuthenticationActions extends ConsumerWidget {
                   : () {
                       ref
                           .read(tpmAuthenticationModelProvider.notifier)
-                          .changeAuthMode(AuthMode.none);
+                          .removeAuthMode();
                     },
               child: Text(l10n.diskEncryptionPageRemovePinButton),
             ),
@@ -812,7 +834,9 @@ class _PinAuthenticationActions extends ConsumerWidget {
           const SizedBox(height: 8),
           YaruInfoBox(
             title: Text(l10n.diskEncryptionPageError),
-            subtitle: Text(tpmState.operationError.toString()),
+            subtitle: Text(
+              tpmState.operationError!.causeByMessage(),
+            ),
             yaruInfoType: YaruInfoType.danger,
           ),
         ],
@@ -875,13 +899,11 @@ class _AuthStatusTileList extends StatelessWidget {
     String? loadingMessage;
     if (pendingOperation != null) {
       loadingMessage = switch (pendingOperation) {
-        AuthOperationRemoving(mode: AuthMode.pin) =>
-          l10n.diskEncryptionPageRemovingPin,
-        AuthOperationRemoving(mode: AuthMode.passphrase) =>
+        TpmFdeOperation.removePin => l10n.diskEncryptionPageRemovingPin,
+        TpmFdeOperation.removePassphrase =>
           l10n.diskEncryptionPageRemovingPassphrase,
-        AuthOperationAdding(mode: AuthMode.pin) =>
-          l10n.diskEncryptionPageAddingPin,
-        AuthOperationAdding(mode: AuthMode.passphrase) =>
+        TpmFdeOperation.addPin => l10n.diskEncryptionPageAddingPin,
+        TpmFdeOperation.addPassphrase =>
           l10n.diskEncryptionPageAddingPassphrase,
         _ => null,
       };

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -74,7 +74,7 @@ sealed class SnapdStateException
 // may be returned by snapd during TPM FDE operations that require polkit authentication
 enum SnapdAuthErrorKind {
   authCancelled('auth-cancelled'),
-  authLoginRequired('auth-login-required');
+  authLoginRequired('login-required');
 
   const SnapdAuthErrorKind(this.snapdKind);
 
@@ -82,7 +82,7 @@ enum SnapdAuthErrorKind {
 
   static SnapdAuthErrorKind? fromKind(String? kind) => switch (kind) {
         'auth-cancelled' => SnapdAuthErrorKind.authCancelled,
-        'auth-login-required' => SnapdAuthErrorKind.authLoginRequired,
+        'login-required' => SnapdAuthErrorKind.authLoginRequired,
         _ => null,
       };
 }

--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -69,6 +69,97 @@ sealed class SnapdStateException
       SnapdStateExceptionUnconnectedSnapInterface;
 }
 
+// Refer to https://github.com/canonical/snapd/blob/master/client/errors.go#L34-L200
+// for a full catalogue of snapd error kinds. The enum contains a subset of errors that
+// may be returned by snapd during TPM FDE operations that require polkit authentication
+enum SnapdAuthErrorKind {
+  authCancelled('auth-cancelled'),
+  authLoginRequired('auth-login-required');
+
+  const SnapdAuthErrorKind(this.snapdKind);
+
+  final String snapdKind;
+
+  static SnapdAuthErrorKind? fromKind(String? kind) => switch (kind) {
+        'auth-cancelled' => SnapdAuthErrorKind.authCancelled,
+        'auth-login-required' => SnapdAuthErrorKind.authLoginRequired,
+        _ => null,
+      };
+}
+
+enum TpmFdeOperation {
+  addPin,
+  addPassphrase,
+  changePin,
+  changePassphrase,
+  removePin,
+  removePassphrase;
+
+  factory TpmFdeOperation.adding(AuthMode mode) => switch (mode) {
+        AuthMode.pin => TpmFdeOperation.addPin,
+        AuthMode.passphrase => TpmFdeOperation.addPassphrase,
+        AuthMode.none => throw ArgumentError.value(mode),
+      };
+
+  factory TpmFdeOperation.changing(AuthMode mode) => switch (mode) {
+        AuthMode.pin => TpmFdeOperation.changePin,
+        AuthMode.passphrase => TpmFdeOperation.changePassphrase,
+        AuthMode.none => throw ArgumentError.value(mode),
+      };
+
+  factory TpmFdeOperation.removing(AuthMode mode) => switch (mode) {
+        AuthMode.pin => TpmFdeOperation.removePin,
+        AuthMode.passphrase => TpmFdeOperation.removePassphrase,
+        AuthMode.none => throw ArgumentError.value(mode),
+      };
+}
+
+@freezed
+sealed class TpmFdeOperationException
+    with _$TpmFdeOperationException
+    implements Exception {
+  const factory TpmFdeOperationException.snapdAuth({
+    required SnapdAuthErrorKind kind,
+    required TpmFdeOperation operation,
+    required SnapdException cause,
+  }) = TpmFdeOperationSnapdAuthException;
+
+  const factory TpmFdeOperationException.snapd({
+    required SnapdException cause,
+    required TpmFdeOperation operation,
+  }) = TpmFdeOperationSnapdException;
+
+  const factory TpmFdeOperationException.unknown({
+    required Exception cause,
+    required TpmFdeOperation operation,
+  }) = TpmFdeOperationUnknownException;
+
+  factory TpmFdeOperationException.from(
+    Exception exception,
+    TpmFdeOperation operation,
+  ) {
+    if (exception is SnapdException) {
+      final kind = SnapdAuthErrorKind.fromKind(exception.kind);
+      if (kind == null) {
+        return TpmFdeOperationException.snapd(
+          cause: exception,
+          operation: operation,
+        );
+      }
+      return TpmFdeOperationException.snapdAuth(
+        kind: kind,
+        operation: operation,
+        cause: exception,
+      );
+    }
+
+    return TpmFdeOperationException.unknown(
+      cause: exception,
+      operation: operation,
+    );
+  }
+}
+
 @freezed
 sealed class TpmStateException with _$TpmStateException implements Exception {
   factory TpmStateException.failed() = TpmStateExceptionFailed;
@@ -98,20 +189,13 @@ sealed class ChangeAuthModeDialogState with _$ChangeAuthModeDialogState {
       ChangeAuthModeDialogStateError;
 }
 
-/// Represents an ongoing operation to replace a platform key.
-@freezed
-sealed class AuthOperation with _$AuthOperation {
-  const factory AuthOperation.adding(AuthMode mode) = AuthOperationAdding;
-  const factory AuthOperation.removing(AuthMode mode) = AuthOperationRemoving;
-}
-
 /// State for TPM authentication mode, including pending operations to change current platform key.
 @freezed
 class TpmAuthState with _$TpmAuthState {
   const factory TpmAuthState({
     required AuthMode currentAuthMode,
-    AuthOperation? pendingOperation,
-    Exception? operationError,
+    TpmFdeOperation? pendingOperation,
+    TpmFdeOperationException? operationError,
   }) = _TpmAuthState;
 
   const TpmAuthState._();
@@ -211,10 +295,25 @@ class ChangeAuthDialogModel extends _$ChangeAuthDialogModel {
         dialogState: ChangeAuthDialogState.success(),
         showPassphrase: false,
       );
+      ref.read(tpmAuthenticationModelProvider.notifier).dismissOperationError();
     } on Exception catch (e) {
-      state = state.copyWith(
-        dialogState: ChangeAuthDialogState.error(e, false),
+      final exception = TpmFdeOperationException.from(
+        e,
+        TpmFdeOperation.changing(state.authMode),
       );
+      switch (exception) {
+        case TpmFdeOperationSnapdAuthException(
+            kind: SnapdAuthErrorKind.authCancelled,
+          ):
+          state = state.copyWith(dialogState: ChangeAuthDialogState.input());
+        case _:
+          state = state.copyWith(
+            dialogState: ChangeAuthDialogState.error(
+              exception,
+              false,
+            ),
+          );
+      }
     }
   }
 
@@ -421,13 +520,17 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
     }
   }
 
-  Future<void> changeAuthMode(AuthMode newMode, {String? passphrase}) async {
+  Future<void> changeAuthMode(
+    AuthMode newMode, {
+    String? passphrase,
+    void Function()? onAuthorized,
+  }) async {
     assert(state.hasValue, 'State must be loaded before changing auth mode');
 
     final currentMode = state.value!.currentAuthMode;
     final operation = newMode == AuthMode.none
-        ? AuthOperation.removing(currentMode)
-        : AuthOperation.adding(newMode);
+        ? TpmFdeOperation.removing(currentMode)
+        : TpmFdeOperation.adding(newMode);
 
     state = AsyncData(
       state.value!.copyWith(
@@ -441,19 +544,46 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
         authMode: newMode,
         passphrase: newMode == AuthMode.passphrase ? passphrase : null,
         pin: newMode == AuthMode.pin ? passphrase : null,
+        onAuthorized: onAuthorized,
       );
 
       // Refresh current mode
       final updatedMode = await _fetchCurrentAuthMode();
       state = AsyncData(
-        TpmAuthState(currentAuthMode: updatedMode),
+        state.value!.copyWith(
+          currentAuthMode: updatedMode,
+          pendingOperation: null,
+          operationError: null,
+        ),
       );
     } on Exception catch (e) {
+      final exception = TpmFdeOperationException.from(e, operation);
       state = AsyncData(
         state.value!.copyWith(
           pendingOperation: null,
-          operationError: e,
+          operationError: exception,
         ),
+      );
+    }
+  }
+
+  Future<void> removeAuthMode({void Function()? onAuthorized}) async {
+    await changeAuthMode(AuthMode.none, onAuthorized: onAuthorized);
+
+    switch (state.valueOrNull?.operationError) {
+      case TpmFdeOperationSnapdAuthException(
+          kind: SnapdAuthErrorKind.authCancelled
+        ):
+        dismissOperationError();
+      case _:
+        break;
+    }
+  }
+
+  void dismissOperationError() {
+    if (state.hasValue) {
+      state = AsyncData(
+        state.value!.copyWith(operationError: null),
       );
     }
   }
@@ -632,6 +762,7 @@ class ChangeAuthModeDialogModel extends _$ChangeAuthModeDialogModel {
       newAuthMode != AuthMode.none,
       'ChangeAuthModeDialogModel does not handle removal (AuthMode.none)',
     );
+    ref.keepAlive();
     ref.onDispose(() {
       _newPassTimer?.cancel();
       _confirmTimer?.cancel();
@@ -642,17 +773,45 @@ class ChangeAuthModeDialogModel extends _$ChangeAuthModeDialogModel {
     );
   }
 
-  Future<void> replaceAuthMode() async {
+  Future<void> replaceAuthMode({
+    void Function()? onAuthorized,
+  }) async {
     assert(state.dialogState is ChangeAuthModeDialogStateInput);
-    state = state.copyWith(dialogState: ChangeAuthModeDialogState.loading());
     try {
-      await ref
-          .read(tpmAuthenticationModelProvider.notifier)
-          .changeAuthMode(state.newAuthMode, passphrase: state.newPass);
-      state = state.copyWith(
-        dialogState: ChangeAuthModeDialogState.success(),
-        showPassphrase: false,
-      );
+      state = state.copyWith(dialogState: ChangeAuthModeDialogState.loading());
+      await ref.read(tpmAuthenticationModelProvider.notifier).changeAuthMode(
+            state.newAuthMode,
+            passphrase: state.newPass,
+            onAuthorized: onAuthorized,
+          );
+      final tpmState = ref.read(tpmAuthenticationModelProvider).valueOrNull;
+      switch (tpmState?.operationError) {
+        case null:
+          state = state.copyWith(
+            dialogState: ChangeAuthModeDialogState.success(),
+            showPassphrase: false,
+          );
+          break;
+
+        case TpmFdeOperationSnapdAuthException(
+            kind: SnapdAuthErrorKind.authCancelled
+          ):
+          state =
+              state.copyWith(dialogState: ChangeAuthModeDialogState.input());
+          ref
+              .read(tpmAuthenticationModelProvider.notifier)
+              .dismissOperationError();
+          break;
+
+        case final exception:
+          state = state.copyWith(
+            dialogState: ChangeAuthModeDialogState.error(
+              exception,
+              false,
+            ),
+          );
+          break;
+      }
     } on Exception catch (e) {
       state = state.copyWith(
         dialogState: ChangeAuthModeDialogState.error(e, false),

--- a/packages/security_center/lib/services/disk_encryption_service.dart
+++ b/packages/security_center/lib/services/disk_encryption_service.dart
@@ -121,6 +121,7 @@ abstract class DiskEncryptionService {
     required AuthMode authMode,
     String? passphrase,
     String? pin,
+    void Function()? onAuthorized,
   });
 
   /// Gets the TPM backed FDE status from snapd.

--- a/packages/security_center/lib/services/fake_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/fake_disk_encryption_service.dart
@@ -136,6 +136,7 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
     required AuthMode authMode,
     String? passphrase,
     String? pin,
+    void Function()? onAuthorized,
   }) async {
     await Future.delayed(const Duration(seconds: 2));
 
@@ -154,6 +155,9 @@ class FakeDiskEncryptionService implements DiskEncryptionService {
       case AuthMode.none:
         _auth = '';
     }
+
+    // Call the onAuthorized hook to indicate authorization is complete and the platform key can be replaced
+    onAuthorized?.call();
 
     // Update the authMode in all platform key slots in systemVolumes
     final updatedVolumes = <String, SnapdSystemVolume>{};

--- a/packages/security_center/lib/services/snapd_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/snapd_disk_encryption_service.dart
@@ -114,6 +114,7 @@ class SnapdDiskEncryptionService implements DiskEncryptionService {
   @override
   Future<void> replacePlatformKey({
     required AuthMode authMode,
+    void Function()? onAuthorized,
     String? passphrase,
     String? pin,
   }) async {
@@ -128,6 +129,8 @@ class SnapdDiskEncryptionService implements DiskEncryptionService {
       passphrase: passphrase,
       pin: pin,
     );
+
+    onAuthorized?.call();
 
     final result =
         await _snapd.watchChange(changeId).firstWhere((change) => change.ready);

--- a/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
+++ b/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
@@ -142,7 +142,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text(tester.l10n.diskEncryptionPageError),
+      find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
       findsNothing,
     );
 
@@ -890,7 +890,7 @@ void main() {
         if (tc.changePinPassphraseError) {
           // Should show error message
           expect(
-            find.text(tester.l10n.diskEncryptionPageError),
+            find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
             findsOneWidget,
           );
           expect(
@@ -955,7 +955,10 @@ void main() {
     );
     await tester.pumpAndSettle(debounceDelay);
 
-    expect(find.text(tester.l10n.diskEncryptionPageError), findsNothing);
+    expect(
+      find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
+      findsNothing,
+    );
     expect(find.byType(TextField), findsNWidgets(3));
     expect(tester.widget<TextField>(textFields.at(0)).controller?.text, '1234');
     expect(tester.widget<TextField>(textFields.at(1)).controller?.text, '5678');
@@ -1661,7 +1664,7 @@ void main() {
         // Check the result based on success/failure
         if (tc.replacePlatformKeyError) {
           expect(
-            find.text(tester.l10n.diskEncryptionPageError),
+            find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
             findsOneWidget,
           );
           expect(
@@ -1681,7 +1684,7 @@ void main() {
           expect(tester.widget<OutlinedButton>(addButton).enabled, isTrue);
         } else {
           expect(
-            find.text(tester.l10n.diskEncryptionPageError),
+            find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
             findsNothing,
           );
         }
@@ -1718,7 +1721,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text(tester.l10n.diskEncryptionPageError), findsNothing);
+    expect(
+      find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
+      findsNothing,
+    );
     expect(find.byType(TextField), findsNWidgets(2));
     expect(tester.widget<TextField>(textFields.at(0)).controller?.text, '5678');
     expect(tester.widget<TextField>(textFields.at(1)).controller?.text, '5678');
@@ -1864,7 +1870,7 @@ void main() {
         if (tc.replacePlatformKeyError) {
           // On error, verify error box appears on main page
           expect(
-            find.text(tester.l10n.diskEncryptionPageError),
+            find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
             findsOneWidget,
           );
           // Button should still be visible and re-enabled
@@ -1880,7 +1886,7 @@ void main() {
           expect(find.text(statusText), findsOneWidget);
         } else {
           expect(
-            find.text(tester.l10n.diskEncryptionPageError),
+            find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
             findsNothing,
           );
         }
@@ -1903,7 +1909,10 @@ void main() {
     await tester.tap(find.text(tester.l10n.diskEncryptionPageRemovePinButton));
     await tester.pumpAndSettle();
 
-    expect(find.text(tester.l10n.diskEncryptionPageError), findsNothing);
+    expect(
+      find.text(tester.l10n.recoveryKeySomethingWentWrongHeader),
+      findsNothing,
+    );
     expect(find.text(tester.l10n.recoveryKeyPinEnabled), findsOneWidget);
     final removeButton = find.widgetWithText(
       OutlinedButton,

--- a/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
+++ b/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
@@ -893,6 +893,14 @@ void main() {
             find.text(tester.l10n.diskEncryptionPageError),
             findsOneWidget,
           );
+          expect(
+            find.text('Exception: Mock change PIN/passphrase error'),
+            findsOneWidget,
+          );
+          expect(
+            find.textContaining('TpmFdeOperationException'),
+            findsNothing,
+          );
 
           // Fields should remain enabled on error (so user can retry)
           for (var i = 0; i < 3; i++) {
@@ -916,6 +924,42 @@ void main() {
         expect(tester.widget<ElevatedButton>(changeButton).enabled, isFalse);
       });
     }
+  });
+
+  testWidgets('change auth - auth cancelled preserves input with no error',
+      (tester) async {
+    final container = createContainer();
+    registerMockDiskEncryptionService(
+      changePinPassphraseSnapdAuthErrorKind: SnapdAuthErrorKind.authCancelled,
+    );
+    await tester.pumpAppWithProviders(
+      (_) => const DiskEncryptionPage(),
+      container,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(tester.l10n.recoveryKeyPinButton));
+    await tester.pumpAndSettle();
+
+    final textFields = find.byType(TextField);
+    await tester.enterText(textFields.at(0), '1234');
+    await tester.enterText(textFields.at(1), '5678');
+    await tester.enterText(textFields.at(2), '5678');
+    await tester.pumpAndSettle(debounceDelay);
+
+    await tester.tap(
+      find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.recoveryKeyPassphraseChange,
+      ),
+    );
+    await tester.pumpAndSettle(debounceDelay);
+
+    expect(find.text(tester.l10n.diskEncryptionPageError), findsNothing);
+    expect(find.byType(TextField), findsNWidgets(3));
+    expect(tester.widget<TextField>(textFields.at(0)).controller?.text, '1234');
+    expect(tester.widget<TextField>(textFields.at(1)).controller?.text, '5678');
+    expect(tester.widget<TextField>(textFields.at(2)).controller?.text, '5678');
   });
 
   group('change auth - input filtering validation', () {
@@ -1620,6 +1664,14 @@ void main() {
             find.text(tester.l10n.diskEncryptionPageError),
             findsOneWidget,
           );
+          expect(
+            find.text('Exception: Mock replace platform key error'),
+            findsOneWidget,
+          );
+          expect(
+            find.textContaining('TpmFdeOperationException'),
+            findsNothing,
+          );
 
           // Add buttons should be re-enabled after error
           final addButtonText = tc.authMode == AuthMode.pin
@@ -1635,6 +1687,82 @@ void main() {
         }
       });
     }
+  });
+
+  testWidgets('add auth mode - auth cancelled preserves input with no error',
+      (tester) async {
+    final container = createContainer();
+    registerMockDiskEncryptionService(
+      authMode: AuthMode.none,
+      replacePlatformKeySnapdAuthErrorKind: SnapdAuthErrorKind.authCancelled,
+    );
+    await tester.pumpAppWithProviders(
+      (_) => const DiskEncryptionPage(),
+      container,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(tester.l10n.diskEncryptionPageAddPinButton));
+    await tester.pumpAndSettle();
+
+    final textFields = find.byType(TextField);
+    await tester.enterText(textFields.at(0), '5678');
+    await tester.enterText(textFields.at(1), '5678');
+    await tester.pumpAndSettle(debounceDelay);
+
+    await tester.tap(
+      find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.diskEncryptionPageAddPinDialogSaveButton,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(tester.l10n.diskEncryptionPageError), findsNothing);
+    expect(find.byType(TextField), findsNWidgets(2));
+    expect(tester.widget<TextField>(textFields.at(0)).controller?.text, '5678');
+    expect(tester.widget<TextField>(textFields.at(1)).controller?.text, '5678');
+  });
+
+  testWidgets('add auth mode - generic snapd error shows cause message',
+      (tester) async {
+    const snapdKind = 'some-other-snapd-error';
+    final container = createContainer();
+    registerMockDiskEncryptionService(
+      authMode: AuthMode.none,
+      replacePlatformKeySnapdErrorKind: snapdKind,
+    );
+    await tester.pumpAppWithProviders(
+      (_) => const DiskEncryptionPage(),
+      container,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(tester.l10n.diskEncryptionPageAddPinButton));
+    await tester.pumpAndSettle();
+
+    final textFields = find.byType(TextField);
+    await tester.enterText(textFields.at(0), '5678');
+    await tester.enterText(textFields.at(1), '5678');
+    await tester.pumpAndSettle(debounceDelay);
+
+    await tester.tap(
+      find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.diskEncryptionPageAddPinDialogSaveButton,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Mock replace platform key snapd error'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('SnapdException(kind: $snapdKind'),
+      findsNothing,
+    );
+    expect(find.textContaining('TpmFdeOperationException'), findsNothing);
   });
 
   group('add auth mode - input filtering validation', () {
@@ -1758,6 +1886,31 @@ void main() {
         }
       });
     }
+  });
+
+  testWidgets('remove auth mode - auth cancelled leaves state unchanged',
+      (tester) async {
+    final container = createContainer();
+    registerMockDiskEncryptionService(
+      replacePlatformKeySnapdAuthErrorKind: SnapdAuthErrorKind.authCancelled,
+    );
+    await tester.pumpAppWithProviders(
+      (_) => const DiskEncryptionPage(),
+      container,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(tester.l10n.diskEncryptionPageRemovePinButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text(tester.l10n.diskEncryptionPageError), findsNothing);
+    expect(find.text(tester.l10n.recoveryKeyPinEnabled), findsOneWidget);
+    final removeButton = find.widgetWithText(
+      OutlinedButton,
+      tester.l10n.diskEncryptionPageRemovePinButton,
+    );
+    expect(removeButton, findsOneWidget);
+    expect(tester.widget<OutlinedButton>(removeButton).enabled, isTrue);
   });
 
   group('TpmAuthenticationModel retry logic', () {

--- a/packages/security_center/test/test_utils.dart
+++ b/packages/security_center/test/test_utils.dart
@@ -136,8 +136,12 @@ DiskEncryptionService registerMockDiskEncryptionService({
   bool generateError = false,
   bool generateAuthCancelled = false,
   bool changePinPassphraseError = false,
+  SnapdAuthErrorKind? changePinPassphraseSnapdAuthErrorKind,
+  String? changePinPassphraseSnapdErrorKind,
   bool entropyCheckError = false,
   bool replacePlatformKeyError = false,
+  SnapdAuthErrorKind? replacePlatformKeySnapdAuthErrorKind,
+  String? replacePlatformKeySnapdErrorKind,
   AuthMode authMode = AuthMode.pin,
   EntropyResponse Function(String)? entropyResponseBuilder,
   bool enumerateKeySlots404Error = false,
@@ -154,6 +158,7 @@ DiskEncryptionService registerMockDiskEncryptionService({
   Object? storageEncryptionError,
 }) {
   final service = MockDiskEncryptionService();
+  var currentAuthMode = authMode;
 
   var storageEncryptedCalls = 0;
   when(service.getStorageEncrypted()).thenAnswer((_) async {
@@ -190,7 +195,7 @@ DiskEncryptionService registerMockDiskEncryptionService({
 
     final platformName = invalidTpmPlatformName ? 'not-tpm2' : 'tpm2';
     final keySlotAuthMode = SnapdSystemVolumeAuthMode.values.firstWhere(
-      (mode) => mode.name == authMode.name,
+      (mode) => mode.name == currentAuthMode.name,
       orElse: () => SnapdSystemVolumeAuthMode.pin,
     );
 
@@ -287,36 +292,73 @@ DiskEncryptionService registerMockDiskEncryptionService({
     if (changePinPassphraseError) {
       throw Exception('Mock change PIN/passphrase error');
     }
+    if (changePinPassphraseSnapdAuthErrorKind != null) {
+      throw SnapdException(
+        message: 'Mock change PIN/passphrase auth error',
+        kind: changePinPassphraseSnapdAuthErrorKind.snapdKind,
+      );
+    }
+    if (changePinPassphraseSnapdErrorKind != null) {
+      throw SnapdException(
+        message: 'Mock change PIN/passphrase snapd error',
+        kind: changePinPassphraseSnapdErrorKind,
+      );
+    }
   });
   when(
     service.replacePlatformKey(
       authMode: anyNamed('authMode'),
       passphrase: anyNamed('passphrase'),
       pin: anyNamed('pin'),
+      onAuthorized: anyNamed('onAuthorized'),
     ),
   ).thenAnswer((invocation) async {
-    final authMode = invocation.namedArguments[#authMode] as AuthMode;
+    final requestedAuthMode = invocation.namedArguments[#authMode] as AuthMode;
     final passphrase = invocation.namedArguments[#passphrase] as String?;
     final pin = invocation.namedArguments[#pin] as String?;
+    final onAuthorized =
+        invocation.namedArguments[#onAuthorized] as void Function()?;
 
-    if (authMode == AuthMode.none && (pin != null || passphrase != null)) {
+    if (requestedAuthMode == AuthMode.none &&
+        (pin != null || passphrase != null)) {
       throw Exception(
         'Mock replace platform key error: PIN or passphrase passed when removing auth (AuthMode.none)',
       );
     }
 
-    if (authMode == AuthMode.pin && (pin == null || pin.isEmpty)) {
+    if (requestedAuthMode == AuthMode.pin && (pin == null || pin.isEmpty)) {
       throw Exception('Mock replace platform key error: missing PIN');
     }
 
-    if (authMode == AuthMode.passphrase &&
+    if (requestedAuthMode == AuthMode.passphrase &&
         (passphrase == null || passphrase.isEmpty)) {
       throw Exception('Mock replace platform key error: missing passphrase');
     }
 
+    // Auth-related errors happen during the polkit prompt itself, before
+    // the snapd RPC is accepted — so onAuthorized must NOT fire in this path.
+    if (replacePlatformKeySnapdAuthErrorKind != null) {
+      throw SnapdException(
+        message: 'Mock replace platform key auth error',
+        kind: replacePlatformKeySnapdAuthErrorKind.snapdKind,
+      );
+    }
+
+    // Mirror the real snapd impl: once polkit authorizes the request and
+    // snapd accepts it (returning a changeId), onAuthorized fires. Any
+    // subsequent failure happens while watching the change.
+    onAuthorized?.call();
+
     if (replacePlatformKeyError) {
       throw Exception('Mock replace platform key error');
     }
+    if (replacePlatformKeySnapdErrorKind != null) {
+      throw SnapdException(
+        message: 'Mock replace platform key snapd error',
+        kind: replacePlatformKeySnapdErrorKind,
+      );
+    }
+    currentAuthMode = requestedAuthMode;
   });
   when(service.pinPassphraseEntropyCheck(any, any))
       .thenAnswer((invocation) async {


### PR DESCRIPTION
## Summary
Improves disk encryption error handling by mapping snapd exceptions to typed TPM FDE operation errors, preserving both the failed operation and snapd error kind. This PR only covers polkit / auth related failures. 

This lets the UI show more specific messages for actions like adding, changing, or removing a PIN/passphrase instead of falling back to generic exception text.

All handled error kinds come from snapd error-kinds definitions defined here:
https://github.com/canonical/snapd/blob/master/client/errors.go#L34-L200

The mapping is intentionally small for now. This can be extended further with more error kinds and for other pages as well by just defining the error-kinds and relevant mappings.

Fixes #145, UDENG-10231

<img width="1087" height="840" alt="image" src="https://github.com/user-attachments/assets/449c8c55-7f63-4344-973b-33230e59758e" />


## Testing
Added end to end tests for ensuring authentication failures correctly show the error messages. Also tested in a `resolute` VM with TPM FDE setup to verify expected behavior and ensure nothing is broken.