### PR TITLE
fix: constrain pages to 575 max width

### DIFF
--- a/packages/security_center/lib/app_permissions/interfaces_page.dart
+++ b/packages/security_center/lib/app_permissions/interfaces_page.dart
@@ -84,7 +84,8 @@ class _Links extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return Wrap(
+      spacing: 16,
       children: _Link.values
           .map(
             (link) => Hyperlink(
@@ -92,8 +93,7 @@ class _Links extends StatelessWidget {
               url: link.url,
             ),
           )
-          .toList()
-          .separatedBy(const SizedBox(width: 16)),
+          .toList(),
     );
   }
 }

--- a/packages/security_center/lib/widgets/scrollable_page.dart
+++ b/packages/security_center/lib/widgets/scrollable_page.dart
@@ -16,11 +16,17 @@ class ScrollablePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: Padding(
-        padding: padding ?? const EdgeInsets.all(kPagePadding),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: children,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 575),
+          child: Padding(
+            padding: padding ?? const EdgeInsets.all(kPagePadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: children,
+            ),
+          ),
         ),
       ),
     );

--- a/packages/security_center/lib/widgets/scrollable_page.dart
+++ b/packages/security_center/lib/widgets/scrollable_page.dart
@@ -16,12 +16,12 @@ class ScrollablePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 575),
-          child: Padding(
-            padding: padding ?? const EdgeInsets.all(kPagePadding),
+      child: Padding(
+        padding: padding ?? const EdgeInsets.all(kPagePadding),
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 574),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: children,


### PR DESCRIPTION
From a conversation width @juanruitina, constrains the content of pages to 575 width so they don't look awkward when resized for large screens.

| Before | After |
|--------|-------|
| <img width="1612" height="704" alt="image" src="https://github.com/user-attachments/assets/ba5714cc-c88b-45aa-b649-ada8efab658b" /> | <img width="1521" height="704" alt="image" src="https://github.com/user-attachments/assets/0bad0572-f08a-4694-97a7-833678ff0a26" /> |

---

UDENG-10512