### PR TITLE
fix: pre-authorize pro attach with a dummy dbus call

### DIFF
--- a/packages/security_center/lib/services/fake_ubuntu_pro_dbus_service.dart
+++ b/packages/security_center/lib/services/fake_ubuntu_pro_dbus_service.dart
@@ -128,6 +128,9 @@ class FakeUbuntuProManagerService implements UbuntuProManagerService {
   }
 
   @override
+  Future<void> preAuthorize() async {}
+
+  @override
   Future<void> attach(String token) async {
     _stream.add(_data.copyWith(attached: true));
   }

--- a/packages/security_center/lib/services/ubuntu_pro_dbus_service.dart
+++ b/packages/security_center/lib/services/ubuntu_pro_dbus_service.dart
@@ -331,6 +331,15 @@ class UbuntuProManagerService {
     await _stream.close();
   }
 
+  /// Pre-authorize the attach flow by calling Attach with an empty token.
+  Future<void> preAuthorize() async {
+    await _objectManager!.callMethod(
+      'com.canonical.UbuntuAdvantage.Manager',
+      'Attach',
+      [DBusString('')],
+    );
+  }
+
   /// Attach the machine over D-Bus.
   Future<void> attach(String token) async {
     await _objectManager!.callMethod(

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
@@ -193,10 +195,18 @@ class _UbuntuProStatus extends ConsumerWidget {
               ),
               const SizedBox(height: kPageSectionGap),
               ElevatedButton(
-                onPressed: () => showDialog(
-                  context: context,
-                  builder: (_) => const AttachDialog(),
-                ),
+                onPressed: () async {
+                  await ref
+                      .read(ubuntuProAttachModelProvider.notifier)
+                      .preAuthorize();
+                  if (!context.mounted) return;
+                  unawaited(
+                    showDialog(
+                      context: context,
+                      builder: (_) => const AttachDialog(),
+                    ),
+                  );
+                },
                 child: Text(l10n.ubuntuProEnablePro),
               ),
               const SizedBox(height: kPageSectionGap),

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
@@ -45,6 +45,14 @@ class UbuntuProAttachModel extends _$UbuntuProAttachModel {
     );
   }
 
+  Future<void> preAuthorize() async {
+    try {
+      await _service.preAuthorize();
+    } on DBusMethodResponseException catch (error) {
+      _log.error('Unable to pre-authorize Pro', error);
+    }
+  }
+
   Future<void> attach() async {
     try {
       state = state.copyWith(state: UbuntuProAttachState.loading());

--- a/packages/security_center/test/utils/ubuntu_pro_utils.dart
+++ b/packages/security_center/test/utils/ubuntu_pro_utils.dart
@@ -145,6 +145,7 @@ UbuntuProManagerService registerMockUbuntuProManagerService({
 
   when(service.data).thenReturn(data);
   when(service.stream).thenAnswer((_) => stream.stream);
+  when(service.preAuthorize()).thenAnswer((_) async {});
   when(service.detach()).thenAnswer((_) async {
     stream.add(
       data.copyWith(attached: false),


### PR DESCRIPTION
The current auth flow for Pro can be a bit awkward, especially with the magic attach flow, since you'll still need to enter your password when confirming. This moves the polkit prompt to before the intial dialog is shown initially by calling Pro attach with an empty token.

This is a bit of a hack, but it does make the flow make a little more sense.

---

UDENG-10513