### PR TITLE
feat: Move Pro attach loading states to the page

### DIFF
--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -248,7 +248,7 @@
     "ubuntuProNotSupportedSnapd": "Ubuntu Pro is not supported by this snapd version",
     "ubuntuProNotSupportedSnapdDetails": "Update snapd to manage Ubuntu Pro",
     "ubuntuProEnabled": "Ubuntu Pro is enabled",
-    "ubuntuProAttachingLabel": "This may take a few seconds...",
+    "ubuntuProLoadingLabel": "This may take a few seconds...",
     "ubuntuProDisabled": "Enterprise-grade security and compliance for your computer. Always free for personal use. {learnMoreLink}",
     "@ubuntuProDisabled": {
         "placeholders": {

--- a/packages/security_center/lib/l10n/app_en.arb
+++ b/packages/security_center/lib/l10n/app_en.arb
@@ -248,6 +248,7 @@
     "ubuntuProNotSupportedSnapd": "Ubuntu Pro is not supported by this snapd version",
     "ubuntuProNotSupportedSnapdDetails": "Update snapd to manage Ubuntu Pro",
     "ubuntuProEnabled": "Ubuntu Pro is enabled",
+    "ubuntuProAttachingLabel": "This may take a few seconds...",
     "ubuntuProDisabled": "Enterprise-grade security and compliance for your computer. Always free for personal use. {learnMoreLink}",
     "@ubuntuProDisabled": {
         "placeholders": {

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -1143,6 +1143,12 @@ abstract class AppLocalizations {
   /// **'Ubuntu Pro is enabled'**
   String get ubuntuProEnabled;
 
+  /// No description provided for @ubuntuProAttachingLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'This may take a few seconds...'**
+  String get ubuntuProAttachingLabel;
+
   /// No description provided for @ubuntuProDisabled.
   ///
   /// In en, this message translates to:

--- a/packages/security_center/lib/l10n/app_localizations.dart
+++ b/packages/security_center/lib/l10n/app_localizations.dart
@@ -1143,11 +1143,11 @@ abstract class AppLocalizations {
   /// **'Ubuntu Pro is enabled'**
   String get ubuntuProEnabled;
 
-  /// No description provided for @ubuntuProAttachingLabel.
+  /// No description provided for @ubuntuProLoadingLabel.
   ///
   /// In en, this message translates to:
   /// **'This may take a few seconds...'**
-  String get ubuntuProAttachingLabel;
+  String get ubuntuProLoadingLabel;
 
   /// No description provided for @ubuntuProDisabled.
   ///

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -543,7 +543,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_am.dart
+++ b/packages/security_center/lib/l10n/app_localizations_am.dart
@@ -543,6 +543,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -548,7 +548,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ar.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ar.dart
@@ -548,6 +548,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -543,7 +543,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_be.dart
+++ b/packages/security_center/lib/l10n/app_localizations_be.dart
@@ -543,6 +543,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -543,7 +543,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_bg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bg.dart
@@ -543,6 +543,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -543,6 +543,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_bn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bn.dart
@@ -543,7 +543,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -543,7 +543,7 @@ class AppLocalizationsBo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_bo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bo.dart
@@ -543,6 +543,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -549,7 +549,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_bs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_bs.dart
@@ -549,6 +549,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -560,6 +560,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro està habilitat';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Seguretat de grau empresarial i compliment per al seu ordinador. Sempre lliure per a ús personal. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ca.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ca.dart
@@ -560,7 +560,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro està habilitat';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -549,6 +549,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro je povoleno';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Zabezpečení a shoda na podnikové úrovni pro váš počítač. Vždy zdarma pro osobní použití. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_cs.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cs.dart
@@ -549,7 +549,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro je povoleno';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -543,6 +543,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_cy.dart
+++ b/packages/security_center/lib/l10n/app_localizations_cy.dart
@@ -543,7 +543,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -543,7 +543,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_da.dart
+++ b/packages/security_center/lib/l10n/app_localizations_da.dart
@@ -543,6 +543,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -562,6 +562,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro ist aktiviert';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Sicherheit und Compliance auf Unternehmensniveau für Ihren Computer. Für den privaten Gebrauch immer kostenlos. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_de.dart
+++ b/packages/security_center/lib/l10n/app_localizations_de.dart
@@ -562,7 +562,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro ist aktiviert';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -543,6 +543,9 @@ class AppLocalizationsDz extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_dz.dart
+++ b/packages/security_center/lib/l10n/app_localizations_dz.dart
@@ -543,7 +543,7 @@ class AppLocalizationsDz extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -560,6 +560,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get ubuntuProEnabled => 'Το Ubuntu Pro είναι ενεργοποιημένο';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Ασφάλεια και συμμόρφωση επιπέδου επιχείρησης για τον υπολογιστή σας. Πάντα δωρεάν για προσωπική χρήση. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_el.dart
+++ b/packages/security_center/lib/l10n/app_localizations_el.dart
@@ -560,7 +560,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get ubuntuProEnabled => 'Το Ubuntu Pro είναι ενεργοποιημένο';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -543,6 +543,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_en.dart
+++ b/packages/security_center/lib/l10n/app_localizations_en.dart
@@ -543,7 +543,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -545,7 +545,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro estas ŝaltita';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_eo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eo.dart
@@ -545,6 +545,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro estas ŝaltita';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Entrepreno-nivelaj sekureco kaj konformiĝo por via komputilo. Ĉiam senkosta por persona uzado. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -559,6 +559,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro está activado';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Seguridad y conformidad normativa de nivel empresarial para su equipo. Siempre gratis para uso personal. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_es.dart
+++ b/packages/security_center/lib/l10n/app_localizations_es.dart
@@ -559,7 +559,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro está activado';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -548,7 +548,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro on kasutusel';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_et.dart
+++ b/packages/security_center/lib/l10n/app_localizations_et.dart
@@ -548,6 +548,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro on kasutusel';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Suurettevõtte tasemel turvalisus ja vastavus sinu arvutile. Isiklikuks kasutuseks alatiseks tasuta saadaval. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -554,7 +554,7 @@ class AppLocalizationsEu extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro gaituta dago';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_eu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_eu.dart
@@ -554,6 +554,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro gaituta dago';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enpresa mailako segurtasuna eta betetzea zure ordenagailurako. Doakoa betiko erabilera pertsonalerako. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -543,6 +543,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_fa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fa.dart
@@ -543,7 +543,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -549,6 +549,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro on käytössä';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Yritystason tietoturvaa ja vaatimustenmukaisuutta tietokoneellesi. Aina ilmainen henkilökohtaiseen käyttöön. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_fi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fi.dart
@@ -549,7 +549,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro on käytössä';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -560,7 +560,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro est activé';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_fr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_fr.dart
@@ -560,6 +560,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro est activé';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Sécurité et conformité de niveau entreprise pour votre ordinateur. Toujours gratuit pour un usage personnel. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -558,7 +558,7 @@ class AppLocalizationsGa extends AppLocalizations {
   String get ubuntuProEnabled => 'Tá Ubuntu Pro cumasaithe';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ga.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ga.dart
@@ -558,6 +558,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get ubuntuProEnabled => 'Tá Ubuntu Pro cumasaithe';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Slándáil agus comhlíonadh den scoth chun do ríomhaire. Saor in aisce i gcónaí le haghaidh úsáide pearsanta. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -558,6 +558,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro está activado';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Seguranza e cumprimento de normas empresariais para o teu computador. Sempre gratuíto para uso persoal. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_gl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gl.dart
@@ -558,7 +558,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro está activado';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -543,6 +543,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_gu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_gu.dart
@@ -543,7 +543,7 @@ class AppLocalizationsGu extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -539,6 +539,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro פעיל';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'אבטחה ברמת תאגיד ועמידה בתקנים למחשב שלך. תמיד חינמי לשימוש פרטי. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_he.dart
+++ b/packages/security_center/lib/l10n/app_localizations_he.dart
@@ -539,7 +539,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro פעיל';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -543,6 +543,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_hi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hi.dart
@@ -543,7 +543,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -543,6 +543,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_hr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hr.dart
@@ -543,7 +543,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -556,6 +556,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get ubuntuProEnabled => 'Az Ubuntu Pro engedélyezve van';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Vállalati szintű biztonság és megfelelőség a számítógépén. Személyes használatra mindig ingyenes. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_hu.dart
+++ b/packages/security_center/lib/l10n/app_localizations_hu.dart
@@ -556,7 +556,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get ubuntuProEnabled => 'Az Ubuntu Pro engedélyezve van';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -547,6 +547,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro diaktifkan';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Keamanan dan kepatuhan tingkat enterprise untuk komputer Anda. Selalu gratis untuk penggunaan pribadi. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_id.dart
+++ b/packages/security_center/lib/l10n/app_localizations_id.dart
@@ -547,7 +547,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro diaktifkan';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -543,7 +543,7 @@ class AppLocalizationsIs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_is.dart
+++ b/packages/security_center/lib/l10n/app_localizations_is.dart
@@ -543,6 +543,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -543,7 +543,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_it.dart
+++ b/packages/security_center/lib/l10n/app_localizations_it.dart
@@ -543,6 +543,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -519,6 +519,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Proは有効です';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'コンピューターにエンタープライズグレードのセキュリティとコンプライアンスを提供します。個人利用の場合は常に無料です。 $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ja.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ja.dart
@@ -519,7 +519,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Proは有効です';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -552,7 +552,7 @@ class AppLocalizationsKa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro ჩართულია';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ka.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ka.dart
@@ -552,6 +552,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro ჩართულია';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'საწარმოო დონის უსაფრთხოება და სტანდარტებთან თავსებადობა თქვენი კომპიუტერისთვის. ყოველთვის უფასო პირადი გამოყენებისთვის. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -543,7 +543,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_kk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kk.dart
@@ -543,6 +543,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -543,7 +543,7 @@ class AppLocalizationsKm extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_km.dart
+++ b/packages/security_center/lib/l10n/app_localizations_km.dart
@@ -543,6 +543,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -553,7 +553,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_kn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_kn.dart
@@ -553,6 +553,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -525,7 +525,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ko.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ko.dart
@@ -525,6 +525,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -543,7 +543,7 @@ class AppLocalizationsKu extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ku.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ku.dart
@@ -543,6 +543,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -541,7 +541,7 @@ class AppLocalizationsLo extends AppLocalizations {
   String get ubuntuProEnabled => 'ເປີດໃຊ້ງານ Ubuntu Pro ແລ້ວ';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_lo.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lo.dart
@@ -541,6 +541,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get ubuntuProEnabled => 'ເປີດໃຊ້ງານ Ubuntu Pro ແລ້ວ';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'ລະບົບຄວາມປອດໄພ ແລະ ການປະຕິບັດຕາມມາດຕະຖານລະດັບອົງກອນສຳລັບຄອມພິວເຕີຂອງທ່ານ. ຟຣີສະເໝີສຳລັບການໃຊ້ງານສ່ວນຕົວ. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -543,6 +543,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_lt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lt.dart
@@ -543,7 +543,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -543,6 +543,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_lv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_lv.dart
@@ -543,7 +543,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -543,7 +543,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_mk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mk.dart
@@ -543,6 +543,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -543,7 +543,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ml.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ml.dart
@@ -543,6 +543,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -543,7 +543,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_mr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_mr.dart
@@ -543,6 +543,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -543,6 +543,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_my.dart
+++ b/packages/security_center/lib/l10n/app_localizations_my.dart
@@ -543,7 +543,7 @@ class AppLocalizationsMy extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -543,6 +543,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_nb.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nb.dart
@@ -543,7 +543,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -543,6 +543,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ne.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ne.dart
@@ -543,7 +543,7 @@ class AppLocalizationsNe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -552,6 +552,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_nl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nl.dart
@@ -552,7 +552,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -543,7 +543,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_nn.dart
+++ b/packages/security_center/lib/l10n/app_localizations_nn.dart
@@ -543,6 +543,9 @@ class AppLocalizationsNn extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -558,7 +558,7 @@ class AppLocalizationsOc extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro es activat';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_oc.dart
+++ b/packages/security_center/lib/l10n/app_localizations_oc.dart
@@ -558,6 +558,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro es activat';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Seguretat e conformitat de qualitat professionala per vòstre ordenador. Totjorn gratuit per un usatge personal. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -543,7 +543,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_pa.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pa.dart
@@ -543,6 +543,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -553,6 +553,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro włączono';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Bezpieczeństwo i zgodność klasy korporacyjnej dla tego komputera. Zawsze za darmo do użytku osobistego. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_pl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pl.dart
@@ -553,7 +553,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro włączono';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -553,6 +553,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_pt.dart
+++ b/packages/security_center/lib/l10n/app_localizations_pt.dart
@@ -553,7 +553,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -543,6 +543,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ro.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ro.dart
@@ -543,7 +543,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -560,6 +560,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get ubuntuProEnabled => 'Сервис Ubuntu Pro активирован';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Безопасность и соответствие стандартам корпоративного уровня для Вашего компьютера. Бесплатно для личного использования. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ru.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ru.dart
@@ -560,7 +560,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get ubuntuProEnabled => 'Сервис Ubuntu Pro активирован';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -543,7 +543,7 @@ class AppLocalizationsSe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_se.dart
+++ b/packages/security_center/lib/l10n/app_localizations_se.dart
@@ -543,6 +543,9 @@ class AppLocalizationsSe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -543,6 +543,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_si.dart
+++ b/packages/security_center/lib/l10n/app_localizations_si.dart
@@ -543,7 +543,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -551,6 +551,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro je aktivované';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Zabezpečenie podnikovej úrovne a dodržiavanie štandardov pre váš počítač. Vždy zadarmo na osobné použitie. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_sk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sk.dart
@@ -551,7 +551,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro je aktivované';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -543,6 +543,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_sl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sl.dart
@@ -543,7 +543,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -543,7 +543,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_sq.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sq.dart
@@ -543,6 +543,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -543,6 +543,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_sr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sr.dart
@@ -543,7 +543,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -550,7 +550,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro är aktiverat';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_sv.dart
+++ b/packages/security_center/lib/l10n/app_localizations_sv.dart
@@ -550,6 +550,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro är aktiverat';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Säkerhet och efterlevnad i företagsklass för din dator. Alltid gratis för privat bruk. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -554,6 +554,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_ta.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ta.dart
@@ -554,7 +554,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -543,6 +543,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_te.dart
+++ b/packages/security_center/lib/l10n/app_localizations_te.dart
@@ -543,7 +543,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -543,6 +543,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_tg.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tg.dart
@@ -543,7 +543,7 @@ class AppLocalizationsTg extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -543,6 +543,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_th.dart
+++ b/packages/security_center/lib/l10n/app_localizations_th.dart
@@ -543,7 +543,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -543,7 +543,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_tl.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tl.dart
@@ -543,6 +543,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -551,6 +551,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro etkinleştirildi';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_tr.dart
+++ b/packages/security_center/lib/l10n/app_localizations_tr.dart
@@ -551,7 +551,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro etkinleştirildi';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -552,7 +552,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro قوزغىتىلغان';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_ug.dart
+++ b/packages/security_center/lib/l10n/app_localizations_ug.dart
@@ -552,6 +552,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro قوزغىتىلغان';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'كومپيۇتېردا كارخانا دەرىجىسىدىكى بىخەتەرلىك ۋە ماسلىشىشچانلىقنى ئىشلىتىش شەخسلەر ئۈچۈن ھەمىشە ھەقسىز. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -556,6 +556,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro увімкнено';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Безпека та відповідність корпоративного рівня для вашого комп\'ютера. Завжди безкоштовно для особистого використання. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_uk.dart
+++ b/packages/security_center/lib/l10n/app_localizations_uk.dart
@@ -556,7 +556,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro увімкнено';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -543,7 +543,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_vi.dart
+++ b/packages/security_center/lib/l10n/app_localizations_vi.dart
@@ -543,6 +543,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -511,7 +511,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
-  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+  String get ubuntuProLoadingLabel => 'This may take a few seconds...';
 
   @override
   String ubuntuProDisabled(String learnMoreLink) {

--- a/packages/security_center/lib/l10n/app_localizations_zh.dart
+++ b/packages/security_center/lib/l10n/app_localizations_zh.dart
@@ -511,6 +511,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get ubuntuProEnabled => 'Ubuntu Pro is enabled';
 
   @override
+  String get ubuntuProAttachingLabel => 'This may take a few seconds...';
+
+  @override
   String ubuntuProDisabled(String learnMoreLink) {
     return 'Enterprise-grade security and compliance for your computer. Always free for personal use. $learnMoreLink';
   }

--- a/packages/security_center/lib/ubuntu_pro/attach_dialog.dart
+++ b/packages/security_center/lib/ubuntu_pro/attach_dialog.dart
@@ -87,12 +87,6 @@ class _MagicLinkDialog extends ConsumerWidget {
     final theme = Theme.of(context);
     final magicAttachProvider = ref.watch(magicAttachModelProvider);
 
-    if (magicAttachProvider.value?.state is UbuntuProAttachStateSuccess) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context, rootNavigator: true).pop();
-      });
-    }
-
     return AlertDialog(
       title: YaruDialogTitleBar(
         titleSpacing: 0,
@@ -120,20 +114,13 @@ class _MagicLinkDialog extends ConsumerWidget {
         data: (data) => data.validContract
             ? [
                 ElevatedButton(
-                  onPressed: magicAttachProvider.value?.state
-                          is UbuntuProAttachStateLoading
-                      ? null
-                      : () =>
-                          ref.read(magicAttachModelProvider.notifier).attach(),
-                  child: magicAttachProvider.value?.state
-                          is UbuntuProAttachStateLoading
-                      ? SizedBox.square(
-                          dimension: theme.textTheme.bodyMedium?.fontSize,
-                          child: YaruCircularProgressIndicator(
-                            strokeWidth: 2,
-                          ),
-                        )
-                      : Text(l10n.ubuntuProEnable),
+                  onPressed: () {
+                    ref.read(ubuntuProPageModelProvider.notifier).attach(
+                          data.response.contractToken!,
+                        );
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                  child: Text(l10n.ubuntuProEnable),
                 ),
               ]
             : null,
@@ -182,16 +169,6 @@ class _MagicLinkDialog extends ConsumerWidget {
                     ),
                   ],
                 ),
-                if (magicAttachProvider.asData?.value.state
-                    is UbuntuProAttachStateError) ...[
-                  SizedBox(height: 8),
-                  Text(
-                    l10n.ubuntuProEnableTokenError,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.error,
-                    ),
-                  ),
-                ],
               ],
             ),
             if (magicAttachProvider.asData?.value.validContract == false)
@@ -223,16 +200,9 @@ class _TokenDialog extends ConsumerStatefulWidget {
 class _TokenDialogState extends ConsumerState<_TokenDialog> {
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
     final provider = ref.watch(ubuntuProAttachModelProvider);
-
-    if (provider.state is UbuntuProAttachStateSuccess) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context, rootNavigator: true).pop();
-      });
-    }
 
     return AlertDialog(
       title: YaruDialogTitleBar(
@@ -259,18 +229,15 @@ class _TokenDialogState extends ConsumerState<_TokenDialog> {
       contentPadding: EdgeInsets.zero,
       actions: [
         ElevatedButton(
-          onPressed: !provider.validToken ||
-                  provider.state is UbuntuProAttachStateLoading
+          onPressed: !provider.validToken
               ? null
-              : () => ref.read(ubuntuProAttachModelProvider.notifier).attach(),
-          child: provider.state is UbuntuProAttachStateLoading
-              ? SizedBox.square(
-                  dimension: theme.textTheme.bodyMedium?.fontSize,
-                  child: YaruCircularProgressIndicator(
-                    strokeWidth: 2,
-                  ),
-                )
-              : Text(l10n.ubuntuProEnable),
+              : () {
+                  ref
+                      .read(ubuntuProPageModelProvider.notifier)
+                      .attach(provider.token);
+                  Navigator.of(context, rootNavigator: true).pop();
+                },
+          child: Text(l10n.ubuntuProEnable),
         ),
       ],
       content: Container(
@@ -284,12 +251,8 @@ class _TokenDialogState extends ConsumerState<_TokenDialog> {
               ),
             ),
             TextField(
-              enabled: provider.state is! UbuntuProAttachStateLoading,
               decoration: InputDecoration(
                 labelText: l10n.ubuntuProTokenLabel,
-                errorText: provider.state is UbuntuProAttachStateError
-                    ? l10n.ubuntuProEnableTokenError
-                    : null,
               ),
               onChanged: (value) => ref
                   .read(ubuntuProAttachModelProvider.notifier)

--- a/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
+++ b/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
@@ -29,7 +29,7 @@ class DetachDialog extends ConsumerWidget {
           ),
           onPressed: () {
             ref.read(ubuntuProPageModelProvider.notifier).detach();
-            Navigator.of(context, rootNavigator: true).pop();
+            Navigator.of(context, rootNavigator: true).pop(true);
           },
           child: Text(l10n.ubuntuProDisable),
         ),

--- a/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
+++ b/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
@@ -38,8 +38,10 @@ class _DetachDialogState extends ConsumerState<DetachDialog> {
               ? null
               : () async {
                   setState(() => _loading = true);
-                  await ref.read(ubuntuProPageModelProvider.notifier).detach();
-                  if (context.mounted) {
+                  final success = await ref
+                      .read(ubuntuProPageModelProvider.notifier)
+                      .detach();
+                  if (context.mounted && success) {
                     Navigator.of(context, rootNavigator: true).pop();
                   }
                 },

--- a/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
+++ b/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
@@ -5,20 +5,20 @@ import 'package:security_center/l10n/app_localizations.dart';
 import 'package:security_center/ubuntu_pro/ubuntu_pro_providers.dart';
 import 'package:yaru/yaru.dart';
 
-class DetachDialog extends ConsumerWidget {
+class DetachDialog extends ConsumerStatefulWidget {
   const DetachDialog({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DetachDialog> createState() => _DetachDialogState();
+}
+
+class _DetachDialogState extends ConsumerState<DetachDialog> {
+  bool _loading = false;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final provider = ref.watch(ubuntuProAttachModelProvider);
-
-    if (provider.state is UbuntuProAttachStateSuccess) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context, rootNavigator: true).pop();
-      });
-    }
 
     return AlertDialog(
       title: YaruDialogTitleBar(
@@ -27,28 +27,26 @@ class DetachDialog extends ConsumerWidget {
       titlePadding: EdgeInsets.zero,
       actions: [
         OutlinedButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
+          onPressed: _loading ? null : Navigator.of(context).pop,
           child: Text(l10n.ubuntuProCancel),
         ),
         ElevatedButton(
           style: ElevatedButton.styleFrom(
             backgroundColor: theme.colorScheme.error,
           ),
-          onPressed: provider.state is UbuntuProAttachStateLoading
+          onPressed: _loading
               ? null
               : () async {
-                  await ref
-                      .read(ubuntuProAttachModelProvider.notifier)
-                      .detach();
+                  setState(() => _loading = true);
+                  await ref.read(ubuntuProPageModelProvider.notifier).detach();
+                  if (context.mounted) {
+                    Navigator.of(context, rootNavigator: true).pop();
+                  }
                 },
-          child: provider.state is UbuntuProAttachStateLoading
+          child: _loading
               ? SizedBox.square(
                   dimension: theme.textTheme.bodyMedium?.fontSize,
-                  child: YaruCircularProgressIndicator(
-                    strokeWidth: 2,
-                  ),
+                  child: const YaruCircularProgressIndicator(strokeWidth: 2),
                 )
               : Text(l10n.ubuntuProDisable),
         ),
@@ -60,13 +58,6 @@ class DetachDialog extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(l10n.ubuntuProDisablePrompt),
-            if (provider.state is UbuntuProAttachStateError) ...[
-              const SizedBox(height: 8),
-              YaruInfoBox(
-                subtitle: Text(l10n.ubuntuProDisableError),
-                yaruInfoType: YaruInfoType.danger,
-              ),
-            ],
           ],
         ),
       ),

--- a/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
+++ b/packages/security_center/lib/ubuntu_pro/detach_dialog.dart
@@ -5,18 +5,11 @@ import 'package:security_center/l10n/app_localizations.dart';
 import 'package:security_center/ubuntu_pro/ubuntu_pro_providers.dart';
 import 'package:yaru/yaru.dart';
 
-class DetachDialog extends ConsumerStatefulWidget {
+class DetachDialog extends ConsumerWidget {
   const DetachDialog({super.key});
 
   @override
-  ConsumerState<DetachDialog> createState() => _DetachDialogState();
-}
-
-class _DetachDialogState extends ConsumerState<DetachDialog> {
-  bool _loading = false;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
@@ -27,30 +20,18 @@ class _DetachDialogState extends ConsumerState<DetachDialog> {
       titlePadding: EdgeInsets.zero,
       actions: [
         OutlinedButton(
-          onPressed: _loading ? null : Navigator.of(context).pop,
+          onPressed: Navigator.of(context).pop,
           child: Text(l10n.ubuntuProCancel),
         ),
         ElevatedButton(
           style: ElevatedButton.styleFrom(
             backgroundColor: theme.colorScheme.error,
           ),
-          onPressed: _loading
-              ? null
-              : () async {
-                  setState(() => _loading = true);
-                  final success = await ref
-                      .read(ubuntuProPageModelProvider.notifier)
-                      .detach();
-                  if (context.mounted && success) {
-                    Navigator.of(context, rootNavigator: true).pop();
-                  }
-                },
-          child: _loading
-              ? SizedBox.square(
-                  dimension: theme.textTheme.bodyMedium?.fontSize,
-                  child: const YaruCircularProgressIndicator(strokeWidth: 2),
-                )
-              : Text(l10n.ubuntuProDisable),
+          onPressed: () {
+            ref.read(ubuntuProPageModelProvider.notifier).detach();
+            Navigator.of(context, rootNavigator: true).pop();
+          },
+          child: Text(l10n.ubuntuProDisable),
         ),
       ],
       content: Container(

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
@@ -167,41 +167,72 @@ class _UbuntuProStatus extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final provider = ref.watch(ubuntuProStatusProvider);
+    final pageState = ref.watch(ubuntuProPageModelProvider);
 
-    return provider.whenOrNull(data: (data) => data.attached) ?? false
-        ? Column(
-            children: [
-              const SizedBox(height: kPageSectionGap),
-              YaruTileList(
-                children: [
-                  YaruListTile(
-                    leading: const Icon(YaruIcons.checkmark, size: kIconSize),
-                    titleText: l10n.ubuntuProEnabled,
-                  ),
-                ],
-              ),
-            ],
-          )
-        : Column(
-            children: [
-              MarkdownText(
-                l10n.ubuntuProDisabled(
-                  l10n.ubuntuProLearnMore.link(kUbuntuProLink),
+    return switch (pageState) {
+      UbuntuProPageStateAttached() => Column(
+          children: [
+            const SizedBox(height: kPageSectionGap),
+            YaruTileList(
+              children: [
+                YaruListTile(
+                  leading: const Icon(YaruIcons.checkmark, size: kIconSize),
+                  titleText: l10n.ubuntuProEnabled,
                 ),
-                alignment: WrapAlignment.center,
+              ],
+            ),
+          ],
+        ),
+      UbuntuProPageStateAttaching() => Column(
+          children: [
+            const SizedBox(height: kPageSectionGap),
+            YaruTileList(
+              children: [
+                YaruListTile(
+                  titleText: l10n.ubuntuProAttachingLabel,
+                  subtitle: const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(height: 8),
+                      YaruLinearProgressIndicator(),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      UbuntuProPageStateDetached() || UbuntuProPageStateError() => Column(
+          children: [
+            MarkdownText(
+              l10n.ubuntuProDisabled(
+                l10n.ubuntuProLearnMore.link(kUbuntuProLink),
               ),
-              const SizedBox(height: kPageSectionGap),
-              ElevatedButton(
-                onPressed: () => showDialog(
+              alignment: WrapAlignment.center,
+            ),
+            const SizedBox(height: kPageSectionGap),
+            ElevatedButton(
+              onPressed: () {
+                ref.read(ubuntuProPageModelProvider.notifier).clearError();
+                showDialog(
                   context: context,
                   builder: (_) => const AttachDialog(),
-                ),
-                child: Text(l10n.ubuntuProEnablePro),
+                );
+              },
+              child: Text(l10n.ubuntuProEnablePro),
+            ),
+            if (pageState is UbuntuProPageStateError) ...[
+              const SizedBox(height: kPageSubsectionGap),
+              YaruInfoBox(
+                yaruInfoType: YaruInfoType.danger,
+                child: Text(l10n.ubuntuProEnableTokenError),
               ),
-              const SizedBox(height: kPageSectionGap),
             ],
-          );
+            const SizedBox(height: kPageSectionGap),
+          ],
+        ),
+    };
   }
 }
 
@@ -214,6 +245,8 @@ class _ESMSection extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final now = DateTime.now();
 
+    final pageState = ref.watch(ubuntuProPageModelProvider);
+    final attaching = pageState is UbuntuProPageStateAttaching;
     final proProvider = ref.watch(ubuntuProStatusProvider);
     final esmAppProvider =
         ref.watch(ubuntuProFeatureModelProvider(UbuntuProFeatureType.esmApps));
@@ -237,7 +270,7 @@ class _ESMSection extends ConsumerWidget {
                 horizontal: 16,
               ),
               value: esmInfraProvider.enabled,
-              onChanged: esmInfraProvider.canToggle
+              onChanged: !attaching && esmInfraProvider.canToggle
                   ? (value) => ref
                       .read(
                         ubuntuProFeatureModelProvider(
@@ -280,7 +313,7 @@ class _ESMSection extends ConsumerWidget {
                 horizontal: 16,
               ),
               value: esmAppProvider.enabled,
-              onChanged: esmAppProvider.canToggle
+              onChanged: !attaching && esmAppProvider.canToggle
                   ? (value) => ref
                       .read(
                         ubuntuProFeatureModelProvider(
@@ -331,6 +364,8 @@ class _LivepatchSection extends ConsumerWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
+    final pageState = ref.watch(ubuntuProPageModelProvider);
+    final attaching = pageState is UbuntuProPageStateAttaching;
     final livepatchProvider = ref
         .watch(ubuntuProFeatureModelProvider(UbuntuProFeatureType.livepatch));
     final statusIconProvider = ref.watch(gSettingsUpdateNotifierModelProvider);
@@ -351,7 +386,7 @@ class _LivepatchSection extends ConsumerWidget {
                 horizontal: 16,
               ),
               value: livepatchProvider.enabled,
-              onChanged: livepatchProvider.canToggle
+              onChanged: !attaching && livepatchProvider.canToggle
                   ? (value) => ref
                       .read(
                         ubuntuProFeatureModelProvider(
@@ -386,12 +421,13 @@ class _LivepatchSection extends ConsumerWidget {
                     data: (data) => data.showStatusIcon,
                   ) ??
                   false,
-              onChanged:
-                  livepatchProvider.enabled && livepatchProvider.canToggle
-                      ? (value) => ref
-                          .read(gSettingsUpdateNotifierModelProvider.notifier)
-                          .toggleStatusIcon(value)
-                      : null,
+              onChanged: !attaching &&
+                      livepatchProvider.enabled &&
+                      livepatchProvider.canToggle
+                  ? (value) => ref
+                      .read(gSettingsUpdateNotifierModelProvider.notifier)
+                      .toggleStatusIcon(value)
+                  : null,
               title: Text(l10n.ubuntuProLivepatchShowTitle),
               contentPadding: const EdgeInsets.symmetric(
                 vertical: 8,

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
@@ -15,16 +15,30 @@ import 'package:security_center/widgets/scrollable_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
 
-class UbuntuProPage extends ConsumerWidget {
+class UbuntuProPage extends ConsumerStatefulWidget {
   const UbuntuProPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<UbuntuProPage> createState() => _UbuntuProPageState();
+}
+
+class _UbuntuProPageState extends ConsumerState<UbuntuProPage> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final featureService = tryGetService<FeatureService>();
 
     return ScrollablePage(
+      controller: _scrollController,
       children: [
         Center(
           child: Row(
@@ -44,7 +58,7 @@ class UbuntuProPage extends ConsumerWidget {
           ),
         ),
         if (featureService?.supportsProControl ?? true)
-          _UbuntuProBody()
+          _UbuntuProBody(scrollController: _scrollController)
         else
           Column(
             children: [
@@ -76,6 +90,10 @@ class UbuntuProPage extends ConsumerWidget {
 }
 
 class _UbuntuProBody extends ConsumerWidget {
+  const _UbuntuProBody({required this.scrollController});
+
+  final ScrollController scrollController;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
@@ -117,10 +135,14 @@ class _UbuntuProBody extends ConsumerWidget {
                 ref
                     .read(ubuntuProPageModelProvider.notifier)
                     .clearDetachError();
-                showDialog(
+                showDialog<bool>(
                   context: context,
                   builder: (_) => const DetachDialog(),
-                );
+                ).then((confirmed) {
+                  if ((confirmed ?? false) && scrollController.hasClients) {
+                    scrollController.jumpTo(0);
+                  }
+                });
               },
               child: Text(l10n.ubuntuProDisablePro),
             ),

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
@@ -226,7 +226,7 @@ class _UbuntuProStatus extends ConsumerWidget {
               const SizedBox(height: kPageSubsectionGap),
               YaruInfoBox(
                 yaruInfoType: YaruInfoType.danger,
-                title: Text(l10n.ubuntuProEnableTokenError),
+                child: Text(l10n.ubuntuProEnableTokenError),
               ),
             ],
             const SizedBox(height: kPageSectionGap),

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
@@ -82,6 +82,8 @@ class _UbuntuProBody extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final navigator = Navigator.of(context);
     final provider = ref.watch(ubuntuProStatusProvider);
+    final pageState = ref.watch(ubuntuProPageModelProvider);
+    final detaching = pageState is UbuntuProPageStateDetaching;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -105,12 +107,16 @@ class _UbuntuProBody extends ConsumerWidget {
               ),
             ],
           ),
-          if (provider.whenOrNull(data: (data) => data.attached) ?? false)
+          if ((provider.whenOrNull(data: (data) => data.attached) ?? false) &&
+              !detaching)
             ElevatedButton(
               style: ElevatedButton.styleFrom(
                 backgroundColor: theme.colorScheme.error,
               ),
               onPressed: () {
+                ref
+                    .read(ubuntuProPageModelProvider.notifier)
+                    .clearDetachError();
                 showDialog(
                   context: context,
                   builder: (_) => const DetachDialog(),
@@ -170,7 +176,7 @@ class _UbuntuProStatus extends ConsumerWidget {
     final pageState = ref.watch(ubuntuProPageModelProvider);
 
     return switch (pageState) {
-      UbuntuProPageStateAttached() => Column(
+      UbuntuProPageStateAttached() || UbuntuProPageStateDetachError() => Column(
           children: [
             const SizedBox(height: kPageSectionGap),
             YaruTileList(
@@ -181,6 +187,13 @@ class _UbuntuProStatus extends ConsumerWidget {
                 ),
               ],
             ),
+            if (pageState is UbuntuProPageStateDetachError) ...[
+              const SizedBox(height: kPageSubsectionGap),
+              YaruInfoBox(
+                yaruInfoType: YaruInfoType.danger,
+                child: Text(l10n.ubuntuProDisableError),
+              ),
+            ],
           ],
         ),
       UbuntuProPageStateAttaching() => Column(
@@ -189,7 +202,7 @@ class _UbuntuProStatus extends ConsumerWidget {
             YaruTileList(
               children: [
                 YaruListTile(
-                  titleText: l10n.ubuntuProAttachingLabel,
+                  titleText: l10n.ubuntuProLoadingLabel,
                   subtitle: const Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
@@ -203,7 +216,27 @@ class _UbuntuProStatus extends ConsumerWidget {
             ),
           ],
         ),
-      UbuntuProPageStateDetached() || UbuntuProPageStateError() => Column(
+      UbuntuProPageStateDetaching() => Column(
+          children: [
+            const SizedBox(height: kPageSectionGap),
+            YaruTileList(
+              children: [
+                YaruListTile(
+                  titleText: l10n.ubuntuProLoadingLabel,
+                  subtitle: const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(height: 8),
+                      YaruLinearProgressIndicator(),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      UbuntuProPageStateDetached() || UbuntuProPageStateAttachError() => Column(
           children: [
             MarkdownText(
               l10n.ubuntuProDisabled(
@@ -214,7 +247,9 @@ class _UbuntuProStatus extends ConsumerWidget {
             const SizedBox(height: kPageSectionGap),
             ElevatedButton(
               onPressed: () {
-                ref.read(ubuntuProPageModelProvider.notifier).clearError();
+                ref
+                    .read(ubuntuProPageModelProvider.notifier)
+                    .clearAttachError();
                 showDialog(
                   context: context,
                   builder: (_) => const AttachDialog(),
@@ -222,7 +257,7 @@ class _UbuntuProStatus extends ConsumerWidget {
               },
               child: Text(l10n.ubuntuProEnablePro),
             ),
-            if (pageState is UbuntuProPageStateError) ...[
+            if (pageState is UbuntuProPageStateAttachError) ...[
               const SizedBox(height: kPageSubsectionGap),
               YaruInfoBox(
                 yaruInfoType: YaruInfoType.danger,
@@ -453,7 +488,7 @@ class _LoadingText extends StatelessWidget {
 
     return Row(
       children: [
-        Text(text),
+        Flexible(child: Text(text)),
         if (isLoading) ...[
           const SizedBox(width: 8),
           SizedBox.square(

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_page.dart
@@ -226,7 +226,7 @@ class _UbuntuProStatus extends ConsumerWidget {
               const SizedBox(height: kPageSubsectionGap),
               YaruInfoBox(
                 yaruInfoType: YaruInfoType.danger,
-                child: Text(l10n.ubuntuProEnableTokenError),
+                title: Text(l10n.ubuntuProEnableTokenError),
               ),
             ],
             const SizedBox(height: kPageSectionGap),

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
@@ -15,17 +15,64 @@ part 'ubuntu_pro_providers.freezed.dart';
 final _log = Logger('ubuntu_pro_providers');
 
 @freezed
-sealed class UbuntuProAttachState with _$UbuntuProAttachState {
-  factory UbuntuProAttachState.input() = UbuntuProAttachStateInput;
-  factory UbuntuProAttachState.loading() = UbuntuProAttachStateLoading;
-  factory UbuntuProAttachState.error() = UbuntuProAttachStateError;
-  factory UbuntuProAttachState.success() = UbuntuProAttachStateSuccess;
+sealed class UbuntuProPageState with _$UbuntuProPageState {
+  factory UbuntuProPageState.detached() = UbuntuProPageStateDetached;
+  factory UbuntuProPageState.attaching() = UbuntuProPageStateAttaching;
+  factory UbuntuProPageState.attached() = UbuntuProPageStateAttached;
+  factory UbuntuProPageState.error() = UbuntuProPageStateError;
+}
+
+@riverpod
+class UbuntuProPageModel extends _$UbuntuProPageModel {
+  final _service = getService<UbuntuProManagerService>();
+  KeepAliveLink? _keepAliveLink;
+
+  @override
+  UbuntuProPageState build() {
+    final status = ref.watch(ubuntuProStatusProvider);
+    final attached = status.whenOrNull(data: (d) => d.attached) ?? false;
+
+    // Do not override transient states driven by an in-flight attach call.
+    if (_keepAliveLink != null) return state;
+
+    return attached
+        ? UbuntuProPageState.attached()
+        : UbuntuProPageState.detached();
+  }
+
+  Future<void> attach(String token) async {
+    _keepAliveLink = ref.keepAlive();
+    state = UbuntuProPageState.attaching();
+    try {
+      await _service.attach(token);
+      state = UbuntuProPageState.attached();
+    } on DBusMethodResponseException catch (error) {
+      _log.error('Unable to attach Pro', error);
+      state = UbuntuProPageState.error();
+    } finally {
+      _keepAliveLink?.close();
+      _keepAliveLink = null;
+    }
+  }
+
+  void clearError() {
+    if (state is UbuntuProPageStateError) {
+      state = UbuntuProPageState.detached();
+    }
+  }
+
+  Future<void> detach() async {
+    try {
+      await _service.detach();
+    } on DBusMethodResponseException catch (error) {
+      _log.error('Unable to detach Pro', error);
+    }
+  }
 }
 
 @freezed
 class UbuntuProData with _$UbuntuProData {
   factory UbuntuProData({
-    required UbuntuProAttachState state,
     @Default('') String token,
   }) = _UbuntuProData;
 
@@ -36,41 +83,10 @@ class UbuntuProData with _$UbuntuProData {
 
 @riverpod
 class UbuntuProAttachModel extends _$UbuntuProAttachModel {
-  final _service = getService<UbuntuProManagerService>();
-
   @override
-  UbuntuProData build() {
-    return UbuntuProData(
-      state: UbuntuProAttachState.input(),
-    );
-  }
-
-  Future<void> attach() async {
-    try {
-      state = state.copyWith(state: UbuntuProAttachState.loading());
-      await _service.attach(state.token);
-      state = state.copyWith(state: UbuntuProAttachState.success());
-    } on DBusMethodResponseException catch (error) {
-      _log.error('Unable to attach Pro', error);
-      state = state.copyWith(state: UbuntuProAttachState.error());
-    }
-  }
-
-  Future<void> detach() async {
-    try {
-      state = state.copyWith(state: UbuntuProAttachState.loading());
-      await _service.detach();
-      state = state.copyWith(state: UbuntuProAttachState.success());
-    } on DBusMethodResponseException catch (error) {
-      _log.error('Unable to detach Pro', error);
-      state = state.copyWith(state: UbuntuProAttachState.error());
-    }
-  }
+  UbuntuProData build() => UbuntuProData();
 
   void setToken(String token) {
-    if (state.state is UbuntuProAttachStateError) {
-      state = state.copyWith(state: UbuntuProAttachState.input());
-    }
     state = state.copyWith(token: token);
   }
 }
@@ -264,7 +280,6 @@ class FIPSModel extends _$FIPSModel {
 @freezed
 class MagicAttachData with _$MagicAttachData {
   factory MagicAttachData({
-    required UbuntuProAttachState state,
     required MagicAttachResponse response,
   }) = _MagicAttachData;
 
@@ -278,7 +293,6 @@ class MagicAttachModel extends _$MagicAttachModel {
   static const refreshDuration = Duration(seconds: 10);
 
   final _service = getService<MagicAttachService>();
-  final _proService = getService<UbuntuProManagerService>();
   late final Timer _timer;
 
   @override
@@ -292,7 +306,6 @@ class MagicAttachModel extends _$MagicAttachModel {
 
     return MagicAttachData(
       response: response,
-      state: UbuntuProAttachState.input(),
     );
   }
 
@@ -305,23 +318,6 @@ class MagicAttachModel extends _$MagicAttachModel {
 
     if (state.value!.validContract) {
       _timer.cancel();
-    }
-  }
-
-  Future<void> attach() async {
-    try {
-      state = AsyncData(
-        state.value!.copyWith(state: UbuntuProAttachState.loading()),
-      );
-      await _proService.attach(state.value!.response.contractToken!);
-      state = AsyncData(
-        state.value!.copyWith(state: UbuntuProAttachState.success()),
-      );
-    } on DBusMethodResponseException catch (error) {
-      _log.error('Unable to attach Pro via magic link', error);
-      state = AsyncData(
-        state.value!.copyWith(state: UbuntuProAttachState.error()),
-      );
     }
   }
 }

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
@@ -61,11 +61,13 @@ class UbuntuProPageModel extends _$UbuntuProPageModel {
     }
   }
 
-  Future<void> detach() async {
+  Future<bool> detach() async {
     try {
       await _service.detach();
+      return true;
     } on DBusMethodResponseException catch (error) {
       _log.error('Unable to detach Pro', error);
+      return false;
     }
   }
 }

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
@@ -34,9 +34,6 @@ class UbuntuProPageModel extends _$UbuntuProPageModel {
     final status = ref.watch(ubuntuProStatusProvider);
     final attached = status.whenOrNull(data: (d) => d.attached) ?? false;
 
-    // Do not override transient states driven by an in-flight attach call.
-    if (_keepAliveLink != null) return state;
-
     return attached
         ? UbuntuProPageState.attached()
         : UbuntuProPageState.detached();

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
@@ -19,7 +19,9 @@ sealed class UbuntuProPageState with _$UbuntuProPageState {
   factory UbuntuProPageState.detached() = UbuntuProPageStateDetached;
   factory UbuntuProPageState.attaching() = UbuntuProPageStateAttaching;
   factory UbuntuProPageState.attached() = UbuntuProPageStateAttached;
-  factory UbuntuProPageState.error() = UbuntuProPageStateError;
+  factory UbuntuProPageState.detaching() = UbuntuProPageStateDetaching;
+  factory UbuntuProPageState.attachError() = UbuntuProPageStateAttachError;
+  factory UbuntuProPageState.detachError() = UbuntuProPageStateDetachError;
 }
 
 @riverpod
@@ -48,26 +50,37 @@ class UbuntuProPageModel extends _$UbuntuProPageModel {
       state = UbuntuProPageState.attached();
     } on DBusMethodResponseException catch (error) {
       _log.error('Unable to attach Pro', error);
-      state = UbuntuProPageState.error();
+      state = UbuntuProPageState.attachError();
     } finally {
       _keepAliveLink?.close();
       _keepAliveLink = null;
     }
   }
 
-  void clearError() {
-    if (state is UbuntuProPageStateError) {
+  void clearAttachError() {
+    if (state is UbuntuProPageStateAttachError) {
       state = UbuntuProPageState.detached();
     }
   }
 
-  Future<bool> detach() async {
+  Future<void> detach() async {
+    _keepAliveLink = ref.keepAlive();
+    state = UbuntuProPageState.detaching();
     try {
       await _service.detach();
-      return true;
+      state = UbuntuProPageState.detached();
     } on DBusMethodResponseException catch (error) {
       _log.error('Unable to detach Pro', error);
-      return false;
+      state = UbuntuProPageState.detachError();
+    } finally {
+      _keepAliveLink?.close();
+      _keepAliveLink = null;
+    }
+  }
+
+  void clearDetachError() {
+    if (state is UbuntuProPageStateDetachError) {
+      state = UbuntuProPageState.attached();
     }
   }
 }

--- a/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
+++ b/packages/security_center/lib/ubuntu_pro/ubuntu_pro_providers.dart
@@ -167,7 +167,8 @@ class UbuntuProFeatureModel extends _$UbuntuProFeatureModel {
   UbuntuProFeatureData build(UbuntuProFeatureType featureType) {
     final feature = _service.getFeature(featureType);
 
-    ref.onDispose(() => state.stream.cancel());
+    final subscription = _service.stream.listen(_featureUpdated);
+    ref.onDispose(subscription.cancel);
     return UbuntuProFeatureData(
       state: feature == null
           ? UbuntuProFeatureState.unavailable()
@@ -175,7 +176,7 @@ class UbuntuProFeatureModel extends _$UbuntuProFeatureModel {
               ? UbuntuProFeatureState.enabled()
               : UbuntuProFeatureState.disabled(),
       data: feature,
-      stream: _service.stream.listen(_featureUpdated),
+      stream: subscription,
     );
   }
 

--- a/packages/security_center/lib/widgets/scrollable_page.dart
+++ b/packages/security_center/lib/widgets/scrollable_page.dart
@@ -6,6 +6,7 @@ class ScrollablePage extends StatelessWidget {
   const ScrollablePage({
     required this.children,
     this.padding,
+    this.controller,
     super.key,
   });
 
@@ -13,9 +14,12 @@ class ScrollablePage extends StatelessWidget {
 
   final EdgeInsetsGeometry? padding;
 
+  final ScrollController? controller;
+
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
+      controller: controller,
       child: Padding(
         padding: padding ?? const EdgeInsets.all(kPagePadding),
         child: Align(

--- a/packages/security_center/test/security_center_app_test.dart
+++ b/packages/security_center/test/security_center_app_test.dart
@@ -9,6 +9,7 @@ import 'package:snapd/snapd.dart';
 import 'package:yaru/yaru.dart';
 
 import 'test_utils.dart';
+import 'utils/ubuntu_pro_utils.dart';
 
 void main() {
   group('app routes', () {
@@ -32,6 +33,8 @@ void main() {
           registerMockDiskEncryptionService(
             storageEncryptionStatus: tc.storageEncryptionStatus,
           );
+          registerMockUbuntuProManagerService();
+          registerMockUbuntuProFeatureService();
           await AvailableRoutes.init();
 
           final container = createContainer();

--- a/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_model_test.dart
+++ b/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_model_test.dart
@@ -96,7 +96,7 @@ void main() {
 
       expect(
         container.read(ubuntuProPageModelProvider),
-        isA<UbuntuProPageStateError>(),
+        isA<UbuntuProPageStateAttachError>(),
       );
     });
 
@@ -118,10 +118,10 @@ void main() {
 
       expect(
         container.read(ubuntuProPageModelProvider),
-        isA<UbuntuProPageStateError>(),
+        isA<UbuntuProPageStateAttachError>(),
       );
 
-      container.read(ubuntuProPageModelProvider.notifier).clearError();
+      container.read(ubuntuProPageModelProvider.notifier).clearAttachError();
       await tester.pumpAndSettle();
 
       expect(
@@ -162,7 +162,41 @@ void main() {
       );
     });
 
-    testWidgets('detach error is swallowed and service handles state',
+    testWidgets('detach success: attached -> detaching -> detached',
+        (tester) async {
+      registerMockUbuntuProManagerService();
+      registerMockUbuntuProFeatureService();
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttached>(),
+      );
+
+      final detachFuture =
+          container.read(ubuntuProPageModelProvider.notifier).detach();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetaching>(),
+      );
+
+      await detachFuture;
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetached>(),
+      );
+    });
+
+    testWidgets('detach failure: attached -> detaching -> detachError',
         (tester) async {
       registerMockUbuntuProManagerService(detachThrows: true);
       registerMockUbuntuProFeatureService();
@@ -174,10 +208,40 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Detach throwing should not propagate — the provider swallows the error.
-      await expectLater(
-        container.read(ubuntuProPageModelProvider.notifier).detach(),
-        completes,
+      await container.read(ubuntuProPageModelProvider.notifier).detach();
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetachError>(),
+      );
+    });
+
+    testWidgets('clearDetachError resets to attached', (tester) async {
+      registerMockUbuntuProManagerService(detachThrows: true);
+      registerMockUbuntuProFeatureService();
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      await container.read(ubuntuProPageModelProvider.notifier).detach();
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetachError>(),
+      );
+
+      container.read(ubuntuProPageModelProvider.notifier).clearDetachError();
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttached>(),
       );
     });
   });

--- a/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_model_test.dart
+++ b/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_model_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:security_center/ubuntu_pro/ubuntu_pro_page.dart';
+import 'package:security_center/ubuntu_pro/ubuntu_pro_providers.dart';
+
+import '../test_utils.dart';
+import '../utils/ubuntu_pro_utils.dart';
+
+void main() {
+  group('UbuntuProPageModel', () {
+    testWidgets('initial state detached when service not attached',
+        (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetached>(),
+      );
+    });
+
+    testWidgets('initial state attached when service attached', (tester) async {
+      registerMockUbuntuProManagerService();
+      registerMockUbuntuProFeatureService();
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttached>(),
+      );
+    });
+
+    testWidgets('attach success: detached -> attaching -> attached',
+        (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetached>(),
+      );
+
+      final attachFuture = container
+          .read(ubuntuProPageModelProvider.notifier)
+          .attach(validToken);
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttaching>(),
+      );
+
+      await attachFuture;
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttached>(),
+      );
+    });
+
+    testWidgets('attach failure: detached -> attaching -> error',
+        (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      await container
+          .read(ubuntuProPageModelProvider.notifier)
+          .attach(invalidToken);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateError>(),
+      );
+    });
+
+    testWidgets('clearError resets to detached', (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      await container
+          .read(ubuntuProPageModelProvider.notifier)
+          .attach(invalidToken);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateError>(),
+      );
+
+      container.read(ubuntuProPageModelProvider.notifier).clearError();
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateDetached>(),
+      );
+    });
+
+    testWidgets('stream does not override attaching state mid-attach',
+        (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      final attachFuture = container
+          .read(ubuntuProPageModelProvider.notifier)
+          .attach(validToken);
+
+      // While the future is pending we should remain in attaching, not flip
+      // to attached from a stream emission.
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttaching>(),
+      );
+
+      await attachFuture;
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(ubuntuProPageModelProvider),
+        isA<UbuntuProPageStateAttached>(),
+      );
+    });
+
+    testWidgets('detach error is swallowed and service handles state',
+        (tester) async {
+      registerMockUbuntuProManagerService(detachThrows: true);
+      registerMockUbuntuProFeatureService();
+      final container = createContainer();
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      // Detach throwing should not propagate — the provider swallows the error.
+      await expectLater(
+        container.read(ubuntuProPageModelProvider.notifier).detach(),
+        completes,
+      );
+    });
+  });
+}

--- a/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
+++ b/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
@@ -436,7 +436,9 @@ class _AttachingPageModel extends UbuntuProPageModel {
   Future<void> attach(String token) async {}
 
   @override
-  Future<void> detach() async {}
+  Future<bool> detach() async {
+    return true;
+  }
 
   @override
   void clearError() {}

--- a/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
+++ b/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
@@ -68,6 +68,55 @@ void main() {
       );
     });
 
+    testWidgets('detaching state shows progress row', (tester) async {
+      registerMockUbuntuProManagerService();
+      registerMockUbuntuProFeatureService();
+      final container = createContainer(
+        overrides: [
+          ubuntuProPageModelProvider.overrideWith(_DetachingPageModel.new),
+        ],
+      );
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pump();
+
+      expect(find.text(tester.l10n.ubuntuProLoadingLabel), findsOne);
+      expect(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProDisablePro),
+        findsNothing,
+      );
+    });
+
+    testWidgets('detach error shows inline error box', (tester) async {
+      registerMockUbuntuProManagerService(detachThrows: true);
+      registerMockUbuntuProFeatureService();
+      await _pumpUbuntuProPage(tester);
+
+      final disableProFinder = find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.ubuntuProDisablePro,
+      );
+      await tester.ensureVisible(disableProFinder);
+      await tester.tap(disableProFinder);
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProDisable),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(find.text(tester.l10n.ubuntuProDisableError), findsOne);
+      expect(find.text(tester.l10n.ubuntuProEnabled), findsOne);
+      expect(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProDisablePro),
+        findsOne,
+      );
+    });
+
     testWidgets('enable-able with token', (tester) async {
       registerMockUbuntuProManagerService(attached: false);
       registerMockUbuntuProFeatureService(featuresEntitled: false);
@@ -247,7 +296,7 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text(tester.l10n.ubuntuProAttachingLabel), findsOne);
+      expect(find.text(tester.l10n.ubuntuProLoadingLabel), findsOne);
       expect(
         find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProEnablePro),
         findsNothing,
@@ -436,10 +485,23 @@ class _AttachingPageModel extends UbuntuProPageModel {
   Future<void> attach(String token) async {}
 
   @override
-  Future<bool> detach() async {
-    return true;
-  }
+  Future<void> detach() async {}
 
   @override
-  void clearError() {}
+  void clearAttachError() {}
+}
+
+// Provider override that permanently returns the detaching state.
+class _DetachingPageModel extends UbuntuProPageModel {
+  @override
+  UbuntuProPageState build() => UbuntuProPageState.detaching();
+
+  @override
+  Future<void> attach(String token) async {}
+
+  @override
+  Future<void> detach() async {}
+
+  @override
+  void clearAttachError() {}
 }

--- a/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
+++ b/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
@@ -281,6 +281,51 @@ void main() {
       );
     });
 
+    testWidgets('scrolls to top after detach dialog closes', (tester) async {
+      registerMockUbuntuProManagerService();
+      registerMockUbuntuProFeatureService();
+
+      // Use a small height so the page content is scrollable.
+      await tester.binding.setSurfaceSize(const Size(800, 300));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpUbuntuProPage(tester);
+
+      final scrollable = tester.widget<SingleChildScrollView>(
+        find.byType(SingleChildScrollView),
+      );
+      final scrollController = scrollable.controller!;
+
+      final disableProFinder = find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.ubuntuProDisablePro,
+      );
+      await tester.ensureVisible(disableProFinder);
+      await tester.pumpAndSettle();
+
+      final scrolledOffset = scrollController.offset;
+      expect(scrolledOffset, greaterThan(0));
+
+      await tester.tap(disableProFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.widgetWithText(OutlinedButton, tester.l10n.ubuntuProCancel),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(scrollController.offset, scrolledOffset);
+
+      await tester.tap(disableProFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProDisable),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(scrollController.offset, 0);
+    });
+
     testWidgets('attaching state shows progress row', (tester) async {
       registerMockUbuntuProManagerService(attached: false);
       registerMockUbuntuProFeatureService(featuresEntitled: false);

--- a/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
+++ b/packages/security_center/test/ubuntu_pro/ubuntu_pro_page_test.dart
@@ -107,13 +107,6 @@ void main() {
 
       expect(tester.widget<ElevatedButton>(enableFinder).enabled, isFalse);
 
-      await tester.enterText(tokenInput, invalidToken);
-      await tester.pumpAndSettle();
-      await tester.tap(enableFinder);
-      await tester.pumpAndSettle();
-
-      expect(find.text(tester.l10n.ubuntuProEnableTokenError), findsOne);
-
       await tester.enterText(tokenInput, validToken);
       await tester.pumpAndSettle();
       await tester.tap(enableFinder);
@@ -128,6 +121,67 @@ void main() {
         ),
         findsOne,
       );
+    });
+
+    testWidgets('token attach error shows inline error box', (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      await _pumpUbuntuProPage(tester);
+
+      final enableProFinder = find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.ubuntuProEnablePro,
+      );
+      await tester.tap(enableProFinder);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(tester.l10n.ubuntuProEnableToken));
+      await tester.pumpAndSettle();
+
+      final tokenInput = find.byType(TextField);
+      await tester.enterText(tokenInput, invalidToken);
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProEnable),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(find.text(tester.l10n.ubuntuProEnableTokenError), findsOne);
+      expect(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProEnablePro),
+        findsOne,
+      );
+    });
+
+    testWidgets('error clears when dialog reopened', (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      await _pumpUbuntuProPage(tester);
+
+      final enableProFinder = find.widgetWithText(
+        ElevatedButton,
+        tester.l10n.ubuntuProEnablePro,
+      );
+
+      await tester.tap(enableProFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(tester.l10n.ubuntuProEnableToken));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), invalidToken);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProEnable),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(tester.l10n.ubuntuProEnableTokenError), findsOne);
+
+      await tester.tap(enableProFinder);
+      await tester.pumpAndSettle();
+
+      expect(find.text(tester.l10n.ubuntuProEnableTokenError), findsNothing);
     });
 
     testWidgets('enable-able via magic link', (tester) async {
@@ -175,6 +229,52 @@ void main() {
           tester.l10n.ubuntuProDisablePro,
         ),
         findsOne,
+      );
+    });
+
+    testWidgets('attaching state shows progress row', (tester) async {
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService(featuresEntitled: false);
+      final container = createContainer(
+        overrides: [
+          ubuntuProPageModelProvider.overrideWith(_AttachingPageModel.new),
+        ],
+      );
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pump();
+
+      expect(find.text(tester.l10n.ubuntuProAttachingLabel), findsOne);
+      expect(
+        find.widgetWithText(ElevatedButton, tester.l10n.ubuntuProEnablePro),
+        findsNothing,
+      );
+    });
+
+    testWidgets('feature switches disabled while attaching', (tester) async {
+      registerMockGSettingsIconService();
+      registerMockUbuntuProManagerService(attached: false);
+      registerMockUbuntuProFeatureService();
+      final container = createContainer(
+        overrides: [
+          ubuntuProPageModelProvider.overrideWith(_AttachingPageModel.new),
+        ],
+      );
+
+      await tester.pumpAppWithProviders(
+        (_) => const UbuntuProPage(),
+        container,
+      );
+      await tester.pump();
+
+      expect(
+        tester
+            .widgetList<YaruSwitchListTile>(find.byType(YaruSwitchListTile))
+            .every((w) => w.onChanged == null),
+        isTrue,
       );
     });
   });
@@ -325,4 +425,19 @@ Future<void> _pumpUbuntuProPage(WidgetTester tester) async {
     container,
   );
   await tester.pumpAndSettle();
+}
+
+// Provider override that permanently returns the attaching state.
+class _AttachingPageModel extends UbuntuProPageModel {
+  @override
+  UbuntuProPageState build() => UbuntuProPageState.attaching();
+
+  @override
+  Future<void> attach(String token) async {}
+
+  @override
+  Future<void> detach() async {}
+
+  @override
+  void clearError() {}
 }

--- a/packages/security_center/test/utils/ubuntu_pro_utils.dart
+++ b/packages/security_center/test/utils/ubuntu_pro_utils.dart
@@ -134,6 +134,7 @@ MagicAttachService registerMockMagicAttachService() {
 UbuntuProManagerService registerMockUbuntuProManagerService({
   bool attached = true,
   bool available = true,
+  bool detachThrows = false,
 }) {
   final service = MockUbuntuProManagerService();
   final stream = StreamController<UbuntuProManagerData>.broadcast();
@@ -145,11 +146,17 @@ UbuntuProManagerService registerMockUbuntuProManagerService({
 
   when(service.data).thenReturn(data);
   when(service.stream).thenAnswer((_) => stream.stream);
-  when(service.detach()).thenAnswer((_) async {
-    stream.add(
-      data.copyWith(attached: false),
+  if (detachThrows) {
+    when(service.detach()).thenThrow(
+      DBusMethodResponseException(DBusMethodErrorResponse('Detach failed')),
     );
-  });
+  } else {
+    when(service.detach()).thenAnswer((_) async {
+      stream.add(
+        data.copyWith(attached: false),
+      );
+    });
+  }
   when(service.attach(validToken)).thenAnswer((_) async {
     stream.add(
       data.copyWith(attached: true),


### PR DESCRIPTION
Previously, the loading state was all held in the attach dialog, which made waiting the duration for Pro to attach a bit cumbersome. This moves the loading state to the page, displaying a loading bar, and if attaching fails then an error will be shown and the user can repeat the flow.

*This will work better with https://github.com/canonical/desktop-security-center/pull/236 (and will likely need a rebase if that merges), since auth as it is now doesn't make a lot of sense if we close the dialog immediately.*

<img width="912" height="720" alt="image" src="https://github.com/user-attachments/assets/b2e28f34-fac1-4830-b3ef-62234406efc2" />

---

UDENG-10514