### PR TITLE
Handle unknown disk encryption status

### DIFF
--- a/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
+++ b/packages/security_center/lib/disk_encryption/disk_encryption_providers.dart
@@ -330,7 +330,7 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
       // for indeterminate state (see LP#2147606)
       final stopwatch = Stopwatch()..start();
       var delay = initialRetryDelay;
-      var storageStatus = await _service.getStorageEncrypted();
+      var storageStatus = await _getStorageEncrypted();
       while (
           storageStatus.status == SnapdStorageEncryptionStatus.indeterminate &&
               stopwatch.elapsed < maxRetryDuration) {
@@ -342,7 +342,7 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
         final remaining = maxRetryDuration - stopwatch.elapsed;
         await Future.delayed(delay < remaining ? delay : remaining);
         delay *= 2;
-        storageStatus = await _service.getStorageEncrypted();
+        storageStatus = await _getStorageEncrypted();
       }
 
       switch (storageStatus.status) {
@@ -406,6 +406,17 @@ class TpmAuthenticationModel extends _$TpmAuthenticationModel {
       if (e.statusCode == 403) {
         throw SnapdStateExceptionUnconnectedSnapInterface();
       }
+      throw TpmStateExceptionFailed();
+    }
+  }
+
+  Future<SnapdStorageEncryptedResponse> _getStorageEncrypted() async {
+    try {
+      return await _service.getStorageEncrypted();
+    } on SnapdException {
+      rethrow;
+    } on ArgumentError catch (e) {
+      _log.error('Failed to parse storage encryption status: $e');
       throw TpmStateExceptionFailed();
     }
   }

--- a/packages/security_center/lib/routes.dart
+++ b/packages/security_center/lib/routes.dart
@@ -172,6 +172,11 @@ class AvailableRoutes {
       if (status.status != SnapdStorageEncryptionStatus.inactive) {
         routes.add(Routes.diskEncryption);
       }
+    } on ArgumentError catch (e) {
+      // If the API call fails, don't show the disk encryption route
+      _log.error(
+        'Failed to get storage encryption status, skipping page registration: $e',
+      );
     } on Exception catch (e) {
       // If the API call fails, don't show the disk encryption route
       _log.error(

--- a/packages/security_center/lib/services/snapd_disk_encryption_service.dart
+++ b/packages/security_center/lib/services/snapd_disk_encryption_service.dart
@@ -140,7 +140,14 @@ class SnapdDiskEncryptionService implements DiskEncryptionService {
   }
 
   @override
-  Future<SnapdStorageEncryptedResponse> getStorageEncrypted() {
-    return _snapd.getStorageEncrypted();
+  Future<SnapdStorageEncryptedResponse> getStorageEncrypted() async {
+    try {
+      return await _snapd.getStorageEncrypted();
+    } on ArgumentError catch (e) {
+      _log.error('Failed to parse storage encryption status: $e');
+      return SnapdStorageEncryptedResponse(
+        status: SnapdStorageEncryptionStatus.failed,
+      );
+    }
   }
 }

--- a/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
+++ b/packages/security_center/test/disk_encryption/disk_encryption_page_test.dart
@@ -969,6 +969,31 @@ void main() {
   });
 
   group('TPM authentication error handling', () {
+    testWidgets('storage encryption status parse error', (tester) async {
+      final container = createContainer();
+      registerMockDiskEncryptionService(
+        storageEncryptionError: ArgumentError('Unknown enum value'),
+      );
+      await tester.pumpAppWithProviders(
+        (_) => const DiskEncryptionPage(),
+        container,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          tester.l10n.diskEncryptionPageErrorFailedToRetrieveStatusHeader,
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.text(
+          tester.l10n.diskEncryptionPageErrorFailedToRetrieveStatusBody,
+        ),
+        findsOneWidget,
+      );
+    });
+
     final cases = [
       (
         name: '404 error from enumerate keyslots API',

--- a/packages/security_center/test/services/snapd_disk_encryption_service_test.dart
+++ b/packages/security_center/test/services/snapd_disk_encryption_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:security_center/services/snapd_disk_encryption_service.dart';
+import 'package:security_center/services/snapd_service.dart';
+import 'package:snapd/snapd.dart';
+
+void main() {
+  test('snapd.dart throws ArgumentError for unknown storage status', () {
+    expect(
+      () => SnapdStorageEncryptedResponse.fromJson({'status': 'future-status'}),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+
+  test('returns failed status when snapd returns an unknown status', () async {
+    final snapd = _FakeSnapdService(
+      storageEncryptionStatus: 'future-status',
+    );
+    addTearDown(snapd.close);
+    final service = SnapdDiskEncryptionService(snapd);
+
+    final response = await service.getStorageEncrypted();
+
+    expect(response.status, SnapdStorageEncryptionStatus.failed);
+  });
+}
+
+class _FakeSnapdService extends SnapdService {
+  _FakeSnapdService({required this.storageEncryptionStatus});
+
+  final String storageEncryptionStatus;
+
+  @override
+  Future<SnapdStorageEncryptedResponse> getStorageEncrypted() async {
+    return SnapdStorageEncryptedResponse.fromJson({
+      'status': storageEncryptionStatus,
+    });
+  }
+}

--- a/packages/security_center/test/test_utils.dart
+++ b/packages/security_center/test/test_utils.dart
@@ -151,11 +151,15 @@ DiskEncryptionService registerMockDiskEncryptionService({
   SnapdStorageEncryptionStatus storageEncryptionStatus =
       SnapdStorageEncryptionStatus.active,
   int indeterminateCallCount = 0,
+  Object? storageEncryptionError,
 }) {
   final service = MockDiskEncryptionService();
 
   var storageEncryptedCalls = 0;
   when(service.getStorageEncrypted()).thenAnswer((_) async {
+    if (storageEncryptionError != null) {
+      throw storageEncryptionError;
+    }
     if (storageEncryptedCalls < indeterminateCallCount) {
       storageEncryptedCalls++;
       return SnapdStorageEncryptedResponse(


### PR DESCRIPTION
## Summary
- handle unknown snapd storage encryption status parse failures without crashing
- map unknown statuses to the existing disk-encryption failure UI and log the parse error
- add a service POC/regression test for actual unexpected enum deserialization

## Testing strategy
Focused service-level regression test that reproduces snapd.dart's actual unknown-enum deserialization failure and verifies it is mapped to a failed disk-encryption status.

Note: broader disk encryption widget tests are currently blocked locally by stale generated code in disk_encryption_providers.freezed.dart referencing TpmFdeOperation/SnapdAuthErrorKind while source uses AuthOperation.